### PR TITLE
Update EmulatorController.m

### DIFF
--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -1181,10 +1181,10 @@ void myosd_handle_turbo() {
     if ( !myosd_inGame ) {
         return;
     }
-    NSArray *supportedTurboButtons = @[ @[ [NSNumber numberWithInt:BTN_X], [NSNumber numberWithInt:MYOSD_X] ],
+    NSArray *supportedTurboButtons = @[ @[ [NSNumber numberWithInt:BTN_X], [NSNumber numberWithInt:MYOSD_A] ],
                                            @[ [NSNumber numberWithInt:BTN_Y], [NSNumber numberWithInt:MYOSD_Y] ],
-                                           @[ [NSNumber numberWithInt:BTN_A], [NSNumber numberWithInt:MYOSD_A] ],
-                                           @[ [NSNumber numberWithInt:BTN_B], [NSNumber numberWithInt:MYOSD_B] ],
+                                           @[ [NSNumber numberWithInt:BTN_A], [NSNumber numberWithInt:MYOSD_B] ],
+                                           @[ [NSNumber numberWithInt:BTN_B], [NSNumber numberWithInt:MYOSD_X] ],
                                            @[ [NSNumber numberWithInt:BTN_L1], [NSNumber numberWithInt:MYOSD_L1] ],
                                            @[ [NSNumber numberWithInt:BTN_R1], [NSNumber numberWithInt:MYOSD_R1] ]
                                            ];
@@ -3095,26 +3095,26 @@ void myosd_handle_turbo() {
             
             if (element == gamepad.buttonA) {
                 if (gamepad.buttonA.pressed) {
-                    myosd_joy_status[index] |= MYOSD_A;
-                }
-                else {
-                    myosd_joy_status[index] &= ~MYOSD_A;
-                }
-            }
-            if (element == gamepad.buttonB) {
-                if (gamepad.buttonB.pressed) {
                     myosd_joy_status[index] |= MYOSD_B;
                 }
                 else {
                     myosd_joy_status[index] &= ~MYOSD_B;
                 }
             }
-            if (element == gamepad.buttonX) {
-                if (gamepad.buttonX.pressed) {
+            if (element == gamepad.buttonB) {
+                if (gamepad.buttonB.pressed) {
                     myosd_joy_status[index] |= MYOSD_X;
                 }
                 else {
                     myosd_joy_status[index] &= ~MYOSD_X;
+                }
+            }
+            if (element == gamepad.buttonX) {
+                if (gamepad.buttonX.pressed) {
+                    myosd_joy_status[index] |= MYOSD_A;
+                }
+                else {
+                    myosd_joy_status[index] &= ~MYOSD_A;
                 }
             }
             if (element == gamepad.buttonY) {
@@ -3147,26 +3147,26 @@ void myosd_handle_turbo() {
             
             if (element == gamepad.buttonA) {
                 if (gamepad.buttonA.pressed) {
-                    myosd_joy_status[index] |= MYOSD_A;
-                }
-                else {
-                    myosd_joy_status[index] &= ~MYOSD_A;
-                }
-            }
-            if (element == gamepad.buttonB) {
-                if (gamepad.buttonB.pressed) {
                     myosd_joy_status[index] |= MYOSD_B;
                 }
                 else {
                     myosd_joy_status[index] &= ~MYOSD_B;
                 }
             }
-            if (element == gamepad.buttonX) {
-                if (gamepad.buttonX.pressed) {
+            if (element == gamepad.buttonB) {
+                if (gamepad.buttonB.pressed) {
                     myosd_joy_status[index] |= MYOSD_X;
                 }
                 else {
                     myosd_joy_status[index] &= ~MYOSD_X;
+                }
+            }
+            if (element == gamepad.buttonX) {
+                if (gamepad.buttonX.pressed) {
+                    myosd_joy_status[index] |= MYOSD_A;
+                }
+                else {
+                    myosd_joy_status[index] &= ~MYOSD_A;
                 }
             }
             if (element == gamepad.buttonY) {


### PR DESCRIPTION
I changed the MFI button layout to a more logical configuration.
Problems:
- Using MFI controller on the main romlist menu the MFI Button A and B are inverted compared to the previous configuration.
- I changed the MFI configuration of the turbo button function to make it consistent with the name printed on the real button of the MFI joystick, but now it's not consistent with the touchscreen button.