### PR TITLE
New background image for landscape no-full view.

### DIFF
--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -1605,7 +1605,7 @@ void myosd_handle_turbo() {
        else if(g_isIphone5)
          imageBack = [ [ UIImageView alloc ] initWithImage:[self loadImage:[NSString stringWithFormat:@"./SKIN_%d/back_landscape_iPhone_5.png",g_pref_skin]]];
 	   else
-	     imageBack = [ [ UIImageView alloc ] initWithImage:[self loadImage:[NSString stringWithFormat:@"./SKIN_%d/back_landscape_iPhone.png",g_pref_skin]]];
+	     imageBack = [ [ UIImageView alloc ] initWithImage:[self loadImage:[NSString stringWithFormat:@"./SKIN_%d/back_landscape_iPhone_6.png",g_pref_skin]]];
 	   
 	   imageBack.frame = rFrames[LANDSCAPE_IMAGE_BACK]; // Set the frame in which the UIImage should be drawn in.
 	   


### PR DESCRIPTION
Loading a new landscape background image for iPhone6/7/8
The image called "back_landscape_iPhone_6.png"is a duplicate of the "back_landscape_iPhone_5.png" already present in the folder.