### PR TITLE
Add support for 4K/UHD and other render resolutions

### DIFF
--- a/iOS-res/Applications/MAME4iOS.app/whatsnew.md
+++ b/iOS-res/Applications/MAME4iOS.app/whatsnew.md
@@ -2,6 +2,7 @@
 
 # Version 2020.7
 
+* Added in 4K/UHD MAME render resolution support so that MAME artwork looks much better
 * Added in iCade support for tvOS 
 * Steam Controller support, controller must be in [bluetooth mode and paired](https://support.steampowered.com/kb_article.php?ref=7728-QESJ-4420)
 * Fixed issue where audio would stop when playing back content from another source or being interrupted by a phone call.

--- a/iOS/OptionsController.m
+++ b/iOS/OptionsController.m
@@ -86,9 +86,9 @@
         
         switchForcepxa = nil;
         
-        arrayEmuRes = [[NSArray alloc] initWithObjects:@"Auto",@"320x200",@"320x240",@"400x300",@"480x300",@"512x384",@"640x400",@"640x480",@"800x600",@"1024x768", nil];
+        arrayEmuRes = [[NSArray alloc] initWithObjects:@"Auto",@"320x200",@"320x240",@"400x300",@"480x300",@"512x384",@"640x400",@"640x480",@"800x600",@"1024x768",@"1280x960",@"1440x1080",@"1600x1200",@"1920x1440",@"2048x1536",@"2880x2160", nil];
                         
-        arrayFSValue = [[NSArray alloc] initWithObjects:@"Auto",@"None", @"1", @"2", @"3",@"4", @"5", @"6", @"7", @"8", @"9", @"10",nil];
+        arrayFSValue = [[NSArray alloc] initWithObjects:@"Auto",@"None", @"1", @"2", @"3",@"4", @"5", @"6", @"7", @"8", @"9", @"10", @"11", @"12", @"13", @"14", @"15", @"16", nil];
         
         arrayOverscanValue = [[NSArray alloc] initWithObjects:@"None",@"1", @"2", @"3",@"4", @"5", @"6", nil];
         

--- a/iOS/ScreenView.m
+++ b/iOS/ScreenView.m
@@ -45,7 +45,7 @@
 #import "Globals.h"
 
 //static
-unsigned short img_buffer [1024 * 768 * 4];//max driver res?
+unsigned short img_buffer [2880 * 2160]; // match max driver res?
 
 
 @interface ScreenLayer : CALayer

--- a/src/osd/droid-ios/osd-droid.c
+++ b/src/osd/droid-ios/osd-droid.c
@@ -94,8 +94,8 @@ unsigned short 	*myosd_screen15 = NULL;
 
 //////////////////////// android
 
-unsigned short prev_screenbuffer[1024 * 1024];
-unsigned short screenbuffer[1024 * 1024];
+unsigned short prev_screenbuffer[2880 * 2160];
+unsigned short screenbuffer[2880 * 2160];
 char globalpath[247]="/sdcard/ROMs/MAME4droid/";
 
 static pthread_mutex_t cond_mutex     = PTHREAD_MUTEX_INITIALIZER;
@@ -322,9 +322,9 @@ void myosd_set_video_mode(int width,int height,int vis_width, int vis_height)
     myosd_vis_video_width = vis_width;
     myosd_vis_video_height = vis_height;
     if(screenbuffer!=NULL)
-	   memset(screenbuffer, 0, 1024*1024*2);
+	   memset(screenbuffer, 0, 2880*2160*2);
     if(prev_screenbuffer!=NULL)
-	   memset(prev_screenbuffer, 0, 1024*1024*2);
+	   memset(prev_screenbuffer, 0, 2880*2160*2);
     if(changeVideo_callback!=NULL)
 	     changeVideo_callback(width, height,vis_width,vis_height);
 

--- a/src/osd/droid-ios/osd-ios.c
+++ b/src/osd/droid-ios/osd-ios.c
@@ -119,10 +119,10 @@ unsigned long myosd_pad_status = 0;
 unsigned long myosd_joy_status[4];
 unsigned short myosd_ext_status = 0;
 
-static unsigned short myosd_screen [1024 * 768 * 4];
+static unsigned short myosd_screen [2880 * 2160];
 unsigned short 	*myosd_screen15 = NULL;
 
-extern unsigned short img_buffer[1024 * 768 * 4];
+extern unsigned short img_buffer[2880 * 2160];
 
 typedef struct AQCallbackStruct {
     AudioQueueRef queue;

--- a/src/osd/droid-ios/osdvideo.c
+++ b/src/osd/droid-ios/osdvideo.c
@@ -204,6 +204,12 @@ void droid_ios_video_render(render_target *our_target)
 			   case 8:{minwidth = 640;minheight = 480;break;}
 			   case 9:{minwidth = 800;minheight = 600;break;}
 			   case 10:{minwidth = 1024;minheight = 768;break;}
+			   case 11:{minwidth = 1280;minheight = 960;break;}
+			   case 12:{minwidth = 1440;minheight = 1080;break;} // Optimal HD: added for 1080P displays
+         		   case 13:{minwidth = 1600;minheight = 1200;break;}
+         		   case 14:{minwidth = 1920;minheight = 1440;break;}
+         		   case 15:{minwidth = 2048;minheight = 1536;break;}
+         		   case 16:{minwidth = 2880;minheight = 2160;break;} // Optimal UHD: added for Consumer 4K/UHD displays		
 			}
 			render_target_compute_visible_area(our_target,minwidth,minheight,4/3,render_target_get_orientation(our_target),&minwidth,&minheight);
 			viswidth = minwidth;

--- a/xcode/MAME4iOS/TVOptionsController.m
+++ b/xcode/MAME4iOS/TVOptionsController.m
@@ -20,8 +20,8 @@
 
 - (id)init {
     if (self = [super init]) {
-        arrayEmuRes = [[NSArray alloc] initWithObjects:@"Auto",@"320x200",@"320x240",@"400x300",@"480x300",@"512x384",@"640x400",@"640x480",@"800x600",@"1024x768", nil];
-        arrayFSValue = [[NSArray alloc] initWithObjects:@"Auto",@"None", @"1", @"2", @"3",@"4", @"5", @"6", @"7", @"8", @"9", @"10",nil];
+        arrayEmuRes = [[NSArray alloc] initWithObjects:@"Auto",@"320x200",@"320x240",@"400x300",@"480x300",@"512x384",@"640x400",@"640x480",@"800x600",@"1024x768",@"1280x960",@"1440x1080",@"1600x1200",@"1920x1440",@"2048x1536",@"2880x2160", nil];
+        arrayFSValue = [[NSArray alloc] initWithObjects:@"Auto",@"None", @"1", @"2", @"3",@"4", @"5", @"6", @"7", @"8", @"9", @"10", @"11", @"12", @"13", @"14", @"15", @"16", nil];
         arrayOverscanValue = [[NSArray alloc] initWithObjects:@"None",@"1", @"2", @"3",@"4", @"5", @"6", nil];
         arrayEmuSpeed = [[NSArray alloc] initWithObjects: @"Default",
                          @"50%", @"60%", @"70%", @"80%", @"85%",@"90%",@"95%",@"100%",


### PR DESCRIPTION
This PR adds support for rendering MAME at a resolution higher than 1024x768 all the way up to UHD/4K.
 
- Rendering at a higher resolution definitely improves the MAME Artwork experience inside the app. 
- New resolutions supported: 1280x960, 1440x1080(Optimal HD: added for 1080P displays), 1600x1200, 1920x1440, 2048x1536, 2880x2160(Optimal UHD: added for 2160P displays)