### PR TITLE
HiRes MAME Artwork

### DIFF
--- a/iOS-res/Applications/MAME4iOS.app/whatsnew.md
+++ b/iOS-res/Applications/MAME4iOS.app/whatsnew.md
@@ -20,6 +20,8 @@
     - Nearest
     - Linear
     - Binlinear
+* Artwork
+    - Artwork is shown at hires by default.
       
 # Version 2020.8
 * Better INFO/HISTORY.DAT display in landscape (and tvOS)

--- a/iOS/CGScreenView.h
+++ b/iOS/CGScreenView.h
@@ -45,8 +45,12 @@
 
 @interface CGScreenView : UIView <ScreenView>
 
-- (id)initWithFrame:(CGRect)frame options:(NSDictionary*)options;
-
 + (CGColorSpaceRef)createColorSpaceFromString:(NSString*)string;
 
+#ifdef DEBUG
++ (void)drawScreenDebugDump;
++ (void)drawScreenDebug:(void*)primatives;
+#endif
+
 @end
+

--- a/iOS/CGScreenView.m
+++ b/iOS/CGScreenView.m
@@ -435,7 +435,7 @@ static BOOL g_render_dump = 0;
                   blend_mode_name[blend], aa ? " AA" : "");
         }
         else if (prim->type == RENDER_PRIMITIVE_QUAD) {
-            NSLog(@"    TEXQ [%.0f,%.0f,%.0f,%.0f] [(%.0f,%.0f),(%.0f,%.0f),(%.0f,%.0f),(%.0f,%.0f)] %s %dx%d (%lX:%d) %s%s%s%s%s%s%s",
+            NSLog(@"    TEXQ [%.0f,%.0f,%.0f,%.0f] [(%.0f,%.0f),(%.0f,%.0f),(%.0f,%.0f),(%.0f,%.0f)] %s %dx%d (%lX:%d) %s%s%s%s%s%s%s%s",
                   prim->bounds_x0, prim->bounds_y0, prim->bounds_x1 - prim->bounds_x0, prim->bounds_y1 - prim->bounds_y0,
                   prim->texcoords[0].u, prim->texcoords[0].v,
                   prim->texcoords[1].u, prim->texcoords[1].v,
@@ -444,7 +444,9 @@ static BOOL g_render_dump = 0;
                   blend_mode_name[blend],
                   prim->texture_width, prim->texture_height, (intptr_t)prim->texture_base, prim->texture_seqid,
                   texture_format_name[fmt],
-                  aa ? " AA" : "", screen ? " SCREEN" : "", wrap ? " WRAP" : "",
+                  prim->texture_palette ? " PALLETE" : "",
+                  aa ? " AA" : "",
+                  screen ? " SCREEN" : "", wrap ? " WRAP" : "",
                   (orient & ORIENTATION_FLIP_X) ? " FLIPX" : "",
                   (orient & ORIENTATION_FLIP_Y) ? " FLIPY" : "",
                   (orient & ORIENTATION_SWAP_XY) ? " SWAPXY" : ""

--- a/iOS/CGScreenView.m
+++ b/iOS/CGScreenView.m
@@ -59,9 +59,18 @@
 }
 
 -(void)setColorSpace:(CGColorSpaceRef)colorSpace {
+    if (colorSpace == _colorSpace)
+        return;
+    
     CGColorSpaceRetain(colorSpace);
     CGColorSpaceRelease(_colorSpace);
     _colorSpace = colorSpace;
+    
+    CGContextRelease(_bitmapContext[0]);
+    _bitmapContext[0] = nil;
+
+    CGContextRelease(_bitmapContext[1]);
+    _bitmapContext[1] = nil;
 }
 
 - (void)setup {
@@ -71,7 +80,8 @@
     
     for (int i=0; i<2; i++) {
         
-        _bitmapContext[i] = CGBitmapContextCreate(myosd_screen + i * (MYOSD_SCREEN_WIDTH * MYOSD_SCREEN_HEIGHT),
+        CGContextRelease(_bitmapContext[i]);
+        _bitmapContext[i] = CGBitmapContextCreate(myosd_screen + i * (MYOSD_BUFFER_WIDTH * MYOSD_BUFFER_HEIGHT),
                                                   myosd_video_width,myosd_video_height,5,myosd_video_width*2,
                                                   _colorSpace,kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder16Little/*kCGImageAlphaNoneSkipLast*/);
         
@@ -79,7 +89,7 @@
         if (_bitmapContext[i] == nil) {
             CGColorSpaceRelease(_colorSpace);
             _colorSpace = CGColorSpaceCreateDeviceRGB();
-            _bitmapContext[i] = CGBitmapContextCreate(myosd_screen + i * (MYOSD_SCREEN_WIDTH * MYOSD_SCREEN_HEIGHT),
+            _bitmapContext[i] = CGBitmapContextCreate(myosd_screen + i * (MYOSD_BUFFER_WIDTH * MYOSD_BUFFER_HEIGHT),
                                                       myosd_video_width,myosd_video_height,5,myosd_video_width*2,
                                                       _colorSpace,kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder16Little/*kCGImageAlphaNoneSkipLast*/);
         }
@@ -89,7 +99,7 @@
 
 - (void)display {
 
-    if (_bitmapContext[0] == nil)
+    if (_bitmapContext[0] == nil || CGBitmapContextGetWidth(_bitmapContext[0]) != myosd_video_width || CGBitmapContextGetHeight(_bitmapContext[0]) != myosd_video_height)
         [self setup];
     
     CGContextRef bitmapContext = (myosd_prev_screen == myosd_screen) ? _bitmapContext[0] :  _bitmapContext[1];
@@ -113,11 +123,27 @@
 
 @implementation CGScreenView {
     NSDictionary* _options;
+
+    #define MAX_MAME_SCREENS 4
+    struct {
+        CGRect bounds;      // location in buffer of screen.
+        CGSize size;        // original size in pixels of screen.
+    }   _mame_screen_info[MAX_MAME_SCREENS];
+    int _mame_screen_count;
 }
 
 + (Class) layerClass
 {
     return [CGScreenLayer class];
+}
+
++ (instancetype)sharedInstance {
+    static id g_sharedInstance;
+    if (g_sharedInstance == nil) {
+        NSParameterAssert([NSThread isMainThread]);
+        g_sharedInstance = [[self alloc] init];
+    }
+    return g_sharedInstance;
 }
 
 - (id)initWithFrame:(CGRect)frame {
@@ -133,16 +159,9 @@
     
 	return self;
 }
-- (id)initWithFrame:(CGRect)frame options:(NSDictionary*)options {
-    self = [self initWithFrame:frame];
+- (void)setOptions:(NSDictionary *)options {
     _options = options;
-    return self;
-}
-- (void)didMoveToWindow {
     
-    if (self.window == nil)
-        return;
-
     // set a custom color space
     NSString* color_space = _options[kScreenViewColorSpace];
 
@@ -172,6 +191,14 @@
         [self.layer setMinificationFilter:kCAFilterNearest];
     }
     
+    // tell layoutSubviews to update the overlay effect.
+    _mame_screen_count = 0;
+    [self setNeedsLayout];
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    
     // remove any previous overlays
     while (self.subviews.count > 0)
         [self.subviews.firstObject removeFromSuperview];
@@ -180,18 +207,15 @@
     NSString* effect = _options[kScreenViewEffect];
     
     if ([effect length] != 0 && ![effect isEqualToString:kScreenViewEffectNone]) {
-        CGRect source_rect = CGRectMake(0, 0, myosd_video_width, myosd_video_height);
-
-        CGRect screen_rect = CGRectMake(0, 0, myosd_video_width, myosd_video_height);
-        if (_options[kScreenViewEffectScreenRect] != nil)
-            screen_rect = [_options[kScreenViewEffectScreenRect] CGRectValue];
-
-        CGSize screen_size = screen_rect.size;
-        if (_options[kScreenViewEffectScreenSize] != nil)
-            screen_size = [_options[kScreenViewEffectScreenSize] CGSizeValue];
-        
-        [self buildEffectOverlay: [effect componentsSeparatedByString:@","]
-                        dst_rect:self.bounds src_rect:source_rect screen_rect:screen_rect screen_pixel_size:screen_size];
+        for (int i=0; i<_mame_screen_count; i++) {
+            
+            CGRect source_rect = CGRectMake(0, 0, myosd_video_width, myosd_video_height);
+            CGRect screen_rect = _mame_screen_info[i].bounds;
+            CGSize screen_size = _mame_screen_info[i].size;
+            
+            [self buildEffectOverlay: [effect componentsSeparatedByString:@","]
+                            dst_rect:self.bounds src_rect:source_rect screen_rect:screen_rect screen_pixel_size:screen_size];
+        }
     }
 }
 
@@ -205,47 +229,45 @@
     // this logic, while doing our real drawing work inside of -drawLayer:inContext:
 }
 
-// you can specify a colorSpace in two ways, with a system name or with parameters.
-// these strings are of the form <colorSpace name OR colorSpace parameters>
-+ (CGColorSpaceRef)createColorSpaceFromString:(NSString*)string {
-    
-    if ([string length] == 0 || [string isEqualToString:@"Default"] || [string isEqualToString:@"DeviceRGB"])
-        return CGColorSpaceCreateDeviceRGB();
-    
-    NSArray* values = [string componentsSeparatedByString:@","];
-    NSAssert(values.count == 1 || values.count == 3 || values.count == 6 || values.count == 9 || values.count == 18, @"bad colorspace string");
-    
-    // named colorSpace
-    if (values.count < 3) {
-        CFStringRef name = (__bridge CFStringRef)[values.firstObject stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-        return CGColorSpaceCreateWithName(name) ?: CGColorSpaceCreateDeviceRGB();
-    }
-    
-    // calibrated color space <white point>, <black point>, <gamma>, <matrix>
-    CGFloat whitePoint[] = {0.0,0.0,0.0};
-    CGFloat blackPoint[] = {0.0,0.0,0.0};
-    CGFloat gamma[] = {1.0,1.0,1.0};
-    CGFloat matrix[] = {1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0};
-    
-    for (int i=0; i<3; i++)
-        whitePoint[i] = [values[0+i] doubleValue];
-    
-    if (values.count >= 6) {
-        for (int i=0; i<3; i++)
-            blackPoint[i] = [values[3+i] doubleValue];
-    }
-    if (values.count >= 9) {
-        for (int i=0; i<3; i++)
-            gamma[i] = [values[6+i] doubleValue];
-    }
-    if (values.count >= 18) {
-        for (int i=0; i<9; i++)
-            matrix[i] = [values[9+i] doubleValue];
-    }
+// return 1 if you handled the draw, 0 for a software render
+// NOTE this is called on MAME background thread, dont do anything stupid.
+//
+// all we do in the CoreGraphics case is find the location of all the SCREENs
+// so we can put effect overlays on top of only them.
+//
+- (int)drawScreen:(void*)prim_list {
 
-    return CGColorSpaceCreateCalibratedRGB(whitePoint, blackPoint, gamma, matrix);
+    int screen_count = 0;
+    
+    // walk the primitive list and find the location and size of the screen(s) in the buffer.
+    for (myosd_render_primitive* prim = prim_list; prim != NULL; prim = prim->next) {
+        if (prim->type == RENDER_PRIMITIVE_QUAD && prim->screentex && prim->texture_base != NULL) {
+
+            if (screen_count == sizeof(_mame_screen_info)/sizeof(_mame_screen_info[0]))
+                break;
+
+            _mame_screen_info[screen_count].bounds.origin.x = floor(prim->bounds_x0);
+            _mame_screen_info[screen_count].bounds.origin.y = floor(prim->bounds_y0);
+            _mame_screen_info[screen_count].bounds.size.width = floor(prim->bounds_x1) - floor(prim->bounds_x0);
+            _mame_screen_info[screen_count].bounds.size.height = floor(prim->bounds_y1) - floor(prim->bounds_y0);
+
+            if (prim->texorient & ORIENTATION_SWAP_XY)
+                _mame_screen_info[screen_count].size = CGSizeMake(prim->texture_height, prim->texture_width);
+            else
+                _mame_screen_info[screen_count].size = CGSizeMake(prim->texture_width, prim->texture_height);
+
+            screen_count++;
+        }
+    }
+    
+    if (_mame_screen_count != screen_count) {
+        [self performSelectorOnMainThread:@selector(setNeedsLayout) withObject:nil waitUntilDone:NO];
+    }
+    _mame_screen_count = screen_count;
+
+    // always return 0 saying we want a software render
+    return 0;
 }
-
 
 //
 //  buildEffectOverlay
@@ -258,22 +280,22 @@
 //
 - (void)buildEffectOverlay:(NSArray<NSString*>*)effects dst_rect:(CGRect)dst_rect src_rect:(CGRect)src_rect screen_rect:(CGRect)screen_rect screen_pixel_size:(CGSize)screen_pixel_size {
     
-    // map the screen rect into the destination
-    dst_rect.origin.x += floor((screen_rect.origin.x - src_rect.origin.x) * dst_rect.size.width / src_rect.size.width);
-    dst_rect.origin.y += floor((screen_rect.origin.y - src_rect.origin.y) * dst_rect.size.height / src_rect.size.height);
-    dst_rect.size.width  = ceil(screen_rect.size.width  * dst_rect.size.width / src_rect.size.width);
-    dst_rect.size.height = ceil(screen_rect.size.height * dst_rect.size.height / src_rect.size.height);
-    
     CGFloat scale = self.window.screen.scale;
 
-    CGSize dst_pixel_size; // calculate the size of an output pixel in the destination, rounded up
+    // map the screen rect into the destination
+    dst_rect.origin.x += floor((screen_rect.origin.x - src_rect.origin.x) * dst_rect.size.width / src_rect.size.width * scale) / scale;
+    dst_rect.origin.y += floor((screen_rect.origin.y - src_rect.origin.y) * dst_rect.size.height / src_rect.size.height * scale) / scale;
+    dst_rect.size.width  = ceil(screen_rect.size.width  * dst_rect.size.width / src_rect.size.width * scale) / scale;
+    dst_rect.size.height = ceil(screen_rect.size.height * dst_rect.size.height / src_rect.size.height * scale) / scale;
+
+    CGSize dst_pixel_size; // calculate the size of an output pixel in the destination
     dst_pixel_size.width  = ceil(dst_rect.size.width  * scale / screen_pixel_size.width)  / scale;
     dst_pixel_size.height = ceil(dst_rect.size.height * scale / screen_pixel_size.height) / scale;
-    
+
     CGSize image_size; // make a image large enough to hold all rounded up pixels
     image_size.width  = dst_pixel_size.width  * screen_pixel_size.width;
     image_size.height = dst_pixel_size.height * screen_pixel_size.height;
-    
+
     __block BOOL show = FALSE;
     UIImage* image = [[[UIGraphicsImageRenderer alloc] initWithSize:image_size] imageWithActions:^(UIGraphicsImageRendererContext* context) {
         for (NSString* effect in effects) {
@@ -304,4 +326,134 @@
     }
 }
 
+
+// you can specify a colorSpace in two ways, with a system name or with parameters.
+// these strings are of the form <colorSpace name OR colorSpace parameters>
++ (CGColorSpaceRef)createColorSpaceFromString:(NSString*)string {
+    
+    static CGColorSpaceRef g_colorspace;
+    static NSString* g_colorspace_string;
+    
+    if ([g_colorspace_string isEqualToString:string]) {
+        CGColorSpaceRetain(g_colorspace);
+        return g_colorspace;
+    }
+    
+    NSArray* values = [string componentsSeparatedByString:@","];
+    NSAssert(values.count == 1 || values.count == 3 || values.count == 6 || values.count == 9 || values.count == 18, @"bad colorspace string");
+
+    CGColorSpaceRef colorSpace;
+
+    if ([string length] == 0 || [string isEqualToString:@"Default"] || [string isEqualToString:@"DeviceRGB"]) {
+        // Default or None
+        colorSpace = nil;
+    }
+    else if (values.count < 3) {
+        // named colorSpace
+        CFStringRef name = (__bridge CFStringRef)[values.firstObject stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+        colorSpace = CGColorSpaceCreateWithName(name);
+    }
+    else {
+        // calibrated color space <white point>, <black point>, <gamma>, <matrix>
+        CGFloat whitePoint[] = {0.0,0.0,0.0};
+        CGFloat blackPoint[] = {0.0,0.0,0.0};
+        CGFloat gamma[] = {1.0,1.0,1.0};
+        CGFloat matrix[] = {1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0};
+        
+        for (int i=0; i<3; i++)
+            whitePoint[i] = [values[0+i] doubleValue];
+        
+        if (values.count >= 6) {
+            for (int i=0; i<3; i++)
+                blackPoint[i] = [values[3+i] doubleValue];
+        }
+        if (values.count >= 9) {
+            for (int i=0; i<3; i++)
+                gamma[i] = [values[6+i] doubleValue];
+        }
+        if (values.count >= 18) {
+            for (int i=0; i<9; i++)
+                matrix[i] = [values[9+i] doubleValue];
+        }
+
+        colorSpace = CGColorSpaceCreateCalibratedRGB(whitePoint, blackPoint, gamma, matrix);
+    }
+    
+    colorSpace = colorSpace ?: CGColorSpaceCreateDeviceRGB();
+    CGColorSpaceRelease(g_colorspace);
+    g_colorspace = colorSpace;
+    g_colorspace_string = string;
+
+    CGColorSpaceRetain(g_colorspace);
+    return g_colorspace;
+}
+
+// DEBUG code to NSLog() the render data, hit key CMD+D or OPTION+D to dump once.
+#ifdef DEBUG
+static BOOL g_render_dump = 0;
+
++ (void)drawScreenDebugDump {
+    g_render_dump = 1;
+}
+
+// NOTE this is called on MAME background thread, dont do anything stupid.
++ (void)drawScreenDebug:(void*)prim_list {
+
+    static char* texture_format_name[] = {"UNDEFINED", "PAL16", "PALA16", "555", "RGB", "ARGB", "YUV16"};
+    static char* blend_mode_name[] = {"NONE", "ALPHA", "MUL", "ADD"};
+    
+    if (g_render_dump == 0)
+        return;
+    g_render_dump = 0;
+    
+    NSLog(@"Draw Screen: %dx%d", myosd_video_width, myosd_video_height);
+    
+    for (myosd_render_primitive* prim = prim_list; prim != NULL; prim = prim->next) {
+        
+        assert(prim->type == RENDER_PRIMITIVE_LINE || prim->type == RENDER_PRIMITIVE_QUAD);
+        assert(prim->blendmode <= BLENDMODE_ADD);
+        assert(prim->texformat <= TEXFORMAT_YUY16);
+        assert(prim->unused == 0);
+
+        int blend = prim->blendmode;
+        int fmt = prim->texformat;
+        int aa = prim->antialias;
+        int screen = prim->screentex;
+        int orient = prim->texorient;
+        int wrap = prim->texwrap;
+
+        if (prim->type == RENDER_PRIMITIVE_LINE) {
+            NSLog(@"    LINE (%.0f,%.0f) -> (%.0f,%.0f) (%0.2f,%0.2f,%0.2f,%0.2f) %f %s%s",
+                  prim->bounds_x0, prim->bounds_y0, prim->bounds_x1, prim->bounds_y1,
+                  prim->color_r, prim->color_g, prim->color_b, prim->color_a,
+                  prim->width, blend_mode_name[blend], aa ? " AA" : "");
+        }
+        else if (prim->type == RENDER_PRIMITIVE_QUAD && prim->texture_base == NULL) {
+            NSLog(@"    QUAD [%.0f,%.0f,%.0f,%.0f] (%0.2f,%0.2f,%0.2f,%0.2f) %s%s",
+                  prim->bounds_x0, prim->bounds_y0, prim->bounds_x1 - prim->bounds_x0, prim->bounds_y1 - prim->bounds_y0,
+                  prim->color_r, prim->color_g, prim->color_b, prim->color_a,
+                  blend_mode_name[blend], aa ? " AA" : "");
+        }
+        else if (prim->type == RENDER_PRIMITIVE_QUAD) {
+            NSLog(@"    TEXQ [%.0f,%.0f,%.0f,%.0f] [(%.0f,%.0f),(%.0f,%.0f),(%.0f,%.0f),(%.0f,%.0f)] %s %dx%d (%lX:%d) %s%s%s%s%s%s%s",
+                  prim->bounds_x0, prim->bounds_y0, prim->bounds_x1 - prim->bounds_x0, prim->bounds_y1 - prim->bounds_y0,
+                  prim->texcoords[0].u, prim->texcoords[0].v,
+                  prim->texcoords[1].u, prim->texcoords[1].v,
+                  prim->texcoords[2].u, prim->texcoords[2].v,
+                  prim->texcoords[3].u, prim->texcoords[3].v,
+                  blend_mode_name[blend],
+                  prim->texture_width, prim->texture_height, (intptr_t)prim->texture_base, prim->texture_seqid,
+                  texture_format_name[fmt],
+                  aa ? " AA" : "", screen ? " SCREEN" : "", wrap ? " WRAP" : "",
+                  (orient & ORIENTATION_FLIP_X) ? " FLIPX" : "",
+                  (orient & ORIENTATION_FLIP_Y) ? " FLIPY" : "",
+                  (orient & ORIENTATION_SWAP_XY) ? " SWAPXY" : ""
+                  );
+        }
+    }
+}
+#endif
+
 @end
+
+

--- a/iOS/EmulatorController.h
+++ b/iOS/EmulatorController.h
@@ -137,6 +137,7 @@
 #endif
 
 - (void)handle_INPUT;
+- (void)commandKey:(char)key;
 
 - (void)updateOptions;
 

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -234,13 +234,16 @@ void iphone_UpdateScreen()
 // called by the OSD layer to render the current frame
 // return 1 if you did the render, 0 if you want a software render.
 // **NOTE** this is called on the MAME background thread, dont do anything stupid.
+// ...not doing something stupid includes not leaking autoreleased objects! use a autorelease pool if you need to!
 int iphone_DrawScreen(myosd_render_primitive* prim_list) {
     
     if (sharedInstance == nil || sharedInstance->screenView == nil)
         return 0;
 
 #ifdef DEBUG
-    [CGScreenView drawScreenDebug:prim_list];
+    @autoreleasepool {
+        [CGScreenView drawScreenDebug:prim_list];
+    }
 #endif
 
     return [sharedInstance->screenView drawScreen:prim_list];

--- a/iOS/OptionsController.m
+++ b/iOS/OptionsController.m
@@ -236,22 +236,21 @@
                }
                case 2:
                {
-                   cell.textLabel.text   = @"Integer Scaling Only";
-                   cell.accessoryView = [self optionSwitchForKey:@"integerScalingOnly"];
-                   break;
-               }
-               case 3:
-               {
                    cell.textLabel.text   = @"Use Metal";
                    cell.accessoryView = [self optionSwitchForKey:@"useMetal"];
                    [(UISwitch*)cell.accessoryView setEnabled:NO];
                    break;
                }
+               case 3:
+               {
+                   cell.textLabel.text   = @"Integer Scaling Only";
+                   cell.accessoryView = [self optionSwitchForKey:@"integerScalingOnly"];
+                   break;
+               }
                case 4:
                {
-                   cell.textLabel.text   = @"Frame Skip";
-                   cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                   cell.detailTextLabel.text = [Options.arrayFSValue optionAtIndex:op.fsvalue];
+                   cell.textLabel.text   = @"Force Pixel Aspect";
+                   cell.accessoryView = [self optionSwitchForKey:@"forcepxa"];
                    break;
                }
                case 5:
@@ -262,8 +261,9 @@
                }
                case 6:
                {
-                   cell.textLabel.text   = @"Force Pixel Aspect";
-                   cell.accessoryView = [self optionSwitchForKey:@"forcepxa"];
+                   cell.textLabel.text   = @"Frame Skip";
+                   cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                   cell.detailTextLabel.text = [Options.arrayFSValue optionAtIndex:op.fsvalue];
                    break;
                }
                case 7:
@@ -530,7 +530,7 @@
                 ListOptionController *listController = [[ListOptionController alloc] initWithKey:@"sourceColorSpace" list:Options.arrayColorSpace title:cell.textLabel.text];
                 [[self navigationController] pushViewController:listController animated:YES];
             }
-            if (row==4){
+            if (row==6){
                 ListOptionController *listController = [[ListOptionController alloc] initWithKey:@"fsvalue" list:Options.arrayFSValue title:cell.textLabel.text];
                 [[self navigationController] pushViewController:listController animated:YES];
             }

--- a/iOS/OptionsController.m
+++ b/iOS/OptionsController.m
@@ -236,34 +236,34 @@
                }
                case 2:
                {
+                   cell.textLabel.text   = @"Integer Scaling Only";
+                   cell.accessoryView = [self optionSwitchForKey:@"integerScalingOnly"];
+                   break;
+               }
+               case 3:
+               {
                    cell.textLabel.text   = @"Use Metal";
                    cell.accessoryView = [self optionSwitchForKey:@"useMetal"];
                    [(UISwitch*)cell.accessoryView setEnabled:NO];
                    break;
                }
-               case 3:
+               case 4:
+               {
+                   cell.textLabel.text   = @"Frame Skip";
+                   cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                   cell.detailTextLabel.text = [Options.arrayFSValue optionAtIndex:op.fsvalue];
+                   break;
+               }
+               case 5:
                {
                    cell.textLabel.text   = @"Throttle";
                    cell.accessoryView = [self optionSwitchForKey:@"throttle"];
                    break;
                }
-               case 4:
+               case 6:
                {
                    cell.textLabel.text   = @"Force Pixel Aspect";
                    cell.accessoryView = [self optionSwitchForKey:@"forcepxa"];
-                   break;
-               }
-               case 5:
-               {
-                   cell.textLabel.text   = @"Integer Scaling Only";
-                   cell.accessoryView = [self optionSwitchForKey:@"integerScalingOnly"];
-                   break;
-               }
-               case 6:
-               {
-                   cell.textLabel.text   = @"Frame Skip";
-                   cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                   cell.detailTextLabel.text = [Options.arrayFSValue optionAtIndex:op.fsvalue];
                    break;
                }
                case 7:
@@ -530,7 +530,7 @@
                 ListOptionController *listController = [[ListOptionController alloc] initWithKey:@"sourceColorSpace" list:Options.arrayColorSpace title:cell.textLabel.text];
                 [[self navigationController] pushViewController:listController animated:YES];
             }
-            if (row==6){
+            if (row==4){
                 ListOptionController *listController = [[ListOptionController alloc] initWithKey:@"fsvalue" list:Options.arrayFSValue title:cell.textLabel.text];
                 [[self navigationController] pushViewController:listController animated:YES];
             }

--- a/iOS/ScreenView.h
+++ b/iOS/ScreenView.h
@@ -47,8 +47,6 @@
 
 #define kScreenViewFilter           @"filter"
 #define kScreenViewEffect           @"effect"
-#define kScreenViewEffectScreenRect @"effect-screen-rect"  // screen rect for effect (in source pixels...)
-#define kScreenViewEffectScreenSize @"effect-screen-size"  // pixel size of the screen rect (in game pixels)
 #define kScreenViewColorSpace       @"colorspace"
 
 #define kScreenViewFilterNearest    @"Nearest"
@@ -59,6 +57,12 @@
 
 @protocol ScreenView <NSObject>
 
-- (instancetype)initWithFrame:(CGRect)frame options:(NSDictionary*)options;
++ (instancetype)sharedInstance;
+
+- (void)setOptions:(NSDictionary*)options;
+
+// return 1 if you handled the draw, 0 for a software render
+// NOTE this is called on MAME background thread, dont do anything stupid.
+- (int)drawScreen:(void*)primatives;
 
 @end

--- a/iOS/iCadeView.m
+++ b/iOS/iCadeView.m
@@ -827,19 +827,12 @@
     if (g_keyboard_state[KEY_LCMD] || g_keyboard_state[KEY_RCMD] ||
         g_keyboard_state[KEY_LALT] || g_keyboard_state[KEY_RALT])
     {
-        switch (keyCode + (isKeyDown ? KEY_DOWN : 0)) {
-            case KEY_RETURN+KEY_DOWN:
-                if (g_device_is_landscape)
-                    g_pref_full_screen_land = g_pref_full_screen_land_joy = !(g_pref_full_screen_land || g_pref_full_screen_land_joy);
-                else
-                    g_pref_full_screen_port = g_pref_full_screen_port_joy = !(g_pref_full_screen_port || g_pref_full_screen_port_joy);
-                [emuController changeUI];
-                return nil;
-            case KEY_I+KEY_DOWN:
-                g_pref_integer_scale_only = !g_pref_integer_scale_only;
-                [emuController changeUI];
-                return nil;
-        }
+        if (isKeyDown && keyCode == KEY_RETURN)
+            [emuController commandKey:'\n'];
+        if (isKeyDown && keyCode >= KEY_A && keyCode <= KEY_Z)
+            [emuController commandKey:'A' + (keyCode - KEY_A)];
+        if (isKeyDown && keyCode >= KEY_0 && keyCode <= KEY_9)
+            [emuController commandKey:'0' + (keyCode - KEY_0)];
     }
     
     // 8BitDo

--- a/src/osd/droid-ios/osd-ios.c
+++ b/src/osd/droid-ios/osd-ios.c
@@ -46,6 +46,8 @@ int  myosd_video_width = 320;
 int  myosd_video_height = 240;
 int  myosd_vis_video_width = 320;
 int  myosd_vis_video_height = 240;
+int  myosd_display_width;
+int  myosd_display_height;
 int  myosd_in_menu = 0;
 int  myosd_res = 1;
 int  myosd_force_pxaspect = 0;
@@ -99,14 +101,14 @@ char myosd_selected_game[MAX_GAME_NAME] = {'\0'};
 
 extern "C" unsigned long read_mfi_controller(unsigned long res);
 
-/*extern */float joy_analog_x[4][4];
-/*extern */float joy_analog_y[4][2];
+/*extern */float joy_analog_x[NUM_JOY][4];
+/*extern */float joy_analog_y[NUM_JOY][2];
 
-float lightgun_x[4];
-float lightgun_y[4];
+float lightgun_x[NUM_JOY];
+float lightgun_y[NUM_JOY];
 
-float mouse_x[4];
-float mouse_y[4];
+float mouse_x[NUM_JOY];
+float mouse_y[NUM_JOY];
 
 int myosd_mouse = 0;
 
@@ -116,12 +118,12 @@ static int isPause = 0;
 static int videot_running = 0;
 
 unsigned long myosd_pad_status = 0;
-unsigned long myosd_joy_status[4];
+unsigned long myosd_joy_status[NUM_JOY];
 unsigned short myosd_ext_status = 0;
 
 unsigned short *myosd_curr_screen = NULL;
 unsigned short *myosd_prev_screen = NULL;
-unsigned short myosd_screen[MYOSD_SCREEN_WIDTH * MYOSD_SCREEN_HEIGHT * 2];
+unsigned short myosd_screen[MYOSD_BUFFER_WIDTH * MYOSD_BUFFER_HEIGHT * 2];
 
 typedef struct AQCallbackStruct {
     AudioQueueRef queue;
@@ -141,8 +143,10 @@ extern int video_thread_priority;
 extern int video_thread_priority_type;
 extern int global_low_latency_sound;
 
-extern "C" void iphone_UpdateScreen(void);
+// OSD functions located in the iOS/tvOS app
 extern "C" void iphone_Reset_Views(void);
+extern "C" void iphone_UpdateScreen(void);
+extern "C" int  iphone_DrawScreen(void*);
 extern "C" void droid_ios_video_thread(void);
 
 extern "C" void change_pause(int value);
@@ -155,32 +159,24 @@ void queue(unsigned char *p,unsigned size);
 unsigned short dequeue(unsigned char *p,unsigned size);
 inline int emptyQueue(void);
 
-
-static void dump_video(void)
+void myosd_video_flip(void)
 {
-    if (myosd_dbl_buffer) {
+    if (myosd_dbl_buffer)
+    {
         myosd_prev_screen = myosd_curr_screen;
         
         if (myosd_curr_screen != myosd_screen)
             myosd_curr_screen = myosd_screen;
         else
-            myosd_curr_screen = myosd_screen + (MYOSD_SCREEN_WIDTH * MYOSD_SCREEN_HEIGHT);
+            myosd_curr_screen = myosd_screen + (MYOSD_BUFFER_WIDTH * MYOSD_BUFFER_HEIGHT);
     }
 
-	iphone_UpdateScreen();
-}
-
-/////////////
-
-void myosd_video_flip(void)
-{
-	dump_video();
+    iphone_UpdateScreen();
 }
 
 void myosd_set_video_mode(int width,int height,int vis_width,int vis_height)
 {
-
-     printf("myosd_set_video_mode: %d %d \n",width,height);
+     printf("myosd_set_video_mode: %dx%d [%dx%d]\n",width,height,vis_width,vis_height);
 
      myosd_video_width = width;
      myosd_video_height = height;
@@ -192,6 +188,10 @@ void myosd_set_video_mode(int width,int height,int vis_width,int vis_height)
   	 myosd_video_flip();
 }
 
+int myosd_video_draw(void* prims)
+{
+    return iphone_DrawScreen(prims);
+}
 
 unsigned long myosd_joystick_read(int n)
 {

--- a/src/osd/droid-ios/osdinput.c
+++ b/src/osd/droid-ios/osdinput.c
@@ -152,9 +152,9 @@ void droid_ios_init_input(running_machine *machine)
 
         input_device *lightgun_device = input_device_add(machine, DEVICE_CLASS_LIGHTGUN, name, NULL);
         if (lightgun_device == NULL) {
-            fatalerror("Error creating lightgun device");
+            fatalerror("Error creating lightgun device\n");
         } else {
-            printf("created lightgun device!");
+            //printf("created lightgun device!\n");
         }
 
        input_device_item_add(lightgun_device, "X Axis", &lightgun_axis[i][0], ITEM_ID_XAXIS, my_axis_get_state);
@@ -164,9 +164,9 @@ void droid_ios_init_input(running_machine *machine)
 	   snprintf(mouse_name, 10, "Mouse %d", i + 1);
 	   input_device *mouse_device = input_device_add(machine, DEVICE_CLASS_MOUSE, mouse_name, NULL);
 	   if (mouse_device == NULL) {
-		   fatalerror("Error creating mouse device");
+		   fatalerror("Error creating mouse device\n");
 	   } else {
-		   printf("Created Mouse Device!");
+		   //printf("Created Mouse Device!\n");
 	   }
 	   input_device_item_add(mouse_device, "X Axis", &mouse_axis[i][0], ITEM_ID_XAXIS, my_axis_get_state);
 	   input_device_item_add(mouse_device, "Y Axis", &mouse_axis[i][1], ITEM_ID_YAXIS, my_axis_get_state);

--- a/src/osd/droid-ios/osdsound.c
+++ b/src/osd/droid-ios/osdsound.c
@@ -13,13 +13,12 @@
 #include <unistd.h>
 #include <math.h>
 
-#include "myosd.h"
-
 // MAME headers
 #include "emu.h"
 #include "osdepend.h"
 
 #include "osdsound.h"
+#include "myosd.h"
 
 static int attenuation = 0;
 

--- a/src/osd/droid-ios/osdvideo.c
+++ b/src/osd/droid-ios/osdvideo.c
@@ -14,8 +14,9 @@
 #include "osdcore.h"
 //#include <malloc.h>
 #include <unistd.h>
-#include "render.h"
 #include "emu.h"
+#include "render.h"
+#include "rendlay.h"
 #include "osdvideo.h"
 
 #include <pthread.h>
@@ -30,9 +31,6 @@ static int curr_screen_width;
 static int curr_screen_height;
 static int curr_vis_area_screen_width;
 static int curr_vis_area_screen_height;
-
-static int hofs;
-static int vofs;
 
 static const render_primitive_list *currlist = NULL;
 static int thread_stopping = 0;
@@ -80,13 +78,6 @@ void droid_ios_init_video(running_machine *machine)
 
 void droid_ios_video_draw()
 {
-	UINT8 *surfptr;
-	INT32 pitch;
-	int bpp;
-
-	bpp = 2;
-	vofs = hofs = 0;
-
 	if(myosd_video_threaded)
 	{
 		pthread_mutex_lock( &cond_mutex );
@@ -114,23 +105,23 @@ void droid_ios_video_draw()
 
 	if(myosd_video_threaded)
 	   osd_lock_acquire(currlist->lock);
+    
+    int should_draw_sw = myosd_video_draw(currlist->head) == 0;
 
-	surfptr = (UINT8 *) myosd_curr_screen;
-
-	pitch = screen_width * 2;
-
-	surfptr += ((vofs * pitch) + (hofs * bpp));
-
+    if (should_draw_sw)
+    {
 #ifdef ANDROID
-	draw_rgb565_draw_primitives(currlist->head, surfptr, screen_width, screen_height, pitch / 2);
+        draw_rgb565_draw_primitives(currlist->head, myosd_curr_screen, screen_width, screen_height, screen_width);
 #else
-	draw_rgb555_draw_primitives(currlist->head, surfptr, screen_width, screen_height, pitch / 2);
+        draw_rgb555_draw_primitives(currlist->head, myosd_curr_screen, screen_width, screen_height, screen_width);
 #endif
+    }
 
 	if(myosd_video_threaded)
 	  osd_lock_release(currlist->lock);
 
-	myosd_video_flip();
+    if (should_draw_sw)
+        myosd_video_flip();
 
 	if(myosd_video_threaded)
 	   pthread_mutex_lock( &cond_mutex );
@@ -148,6 +139,15 @@ void droid_ios_video_thread()
 	{
 		droid_ios_video_draw();
 	}
+}
+
+// HACK function to get current view from render target
+// TODO: move it into render.c??
+// TODO: make a function called render_target_has_art()??
+layout_view * render_target_get_current_view(render_target *target)
+{
+    //return target->curview;
+    return (layout_view *)((void**)target)[2];
 }
 
 void droid_ios_video_render(render_target *our_target)
@@ -172,25 +172,28 @@ void droid_ios_video_render(render_target *our_target)
 
 		   int w,h;
 		   render_target_compute_visible_area(our_target,minwidth,minheight,4/3,render_target_get_orientation(our_target),&w, &h);
-
 		   viswidth = w;
 		   visheight = h;
-
-		   /*
-		   float ratio = (float)w / (float)h;
-
-		   int new_w = minheight *  ratio;
-		   int new_h = minwidth * (1/ratio);
-
-		   if(new_w > minwidth && new_w<=1024)
-		   {
-			   minwidth = new_w;
-		   }
-		   else
-		   {
-			   minheight = new_h;
-		   }
-		   */
+            
+           // if the current view has artwork we want to use the largest target we can, to fit the display.
+           // in the no art case, use the minimal buffer size needed, so it gets scaled up by hardware.
+           layout_view * view = render_target_get_current_view(our_target);
+            
+           if (layout_view_has_art(view) && myosd_display_width > viswidth && myosd_display_height > visheight)
+           {
+                if (myosd_display_width < myosd_display_height * viswidth / visheight)
+                {
+                    visheight = visheight * myosd_display_width / viswidth;
+                    viswidth  = myosd_display_width;
+                }
+                else
+                {
+                    viswidth  = viswidth * myosd_display_height / visheight;
+                    visheight = myosd_display_height;
+                }
+                minwidth = viswidth;
+                minheight = visheight;
+           }
 		}
 		else
 		{
@@ -217,6 +220,9 @@ void droid_ios_video_render(render_target *our_target)
 		}
 
 		if(minwidth%2!=0)minwidth++;
+        
+        minwidth  = MIN(MYOSD_BUFFER_WIDTH, minwidth);
+        minheight = MIN(MYOSD_BUFFER_HEIGHT, minheight);
 
 		// make that the size of our target
 		render_target_set_bounds(our_target, minwidth, minheight, 0);
@@ -239,6 +245,8 @@ void droid_ios_video_render(render_target *our_target)
 	   pthread_mutex_unlock( &cond_mutex );
 }
 
+#ifdef ANDROID
+
 #define FUNC_PREFIX(x)		draw_rgb565_##x
 #define PIXEL_TYPE			UINT16
 #define SRCSHIFT_R			3
@@ -250,6 +258,8 @@ void droid_ios_video_render(render_target *our_target)
 
 #include "rendersw.c"
 
+#else
+
 #define FUNC_PREFIX(x)		draw_rgb555_##x
 #define PIXEL_TYPE			UINT16
 #define SRCSHIFT_R			3
@@ -260,3 +270,5 @@ void droid_ios_video_render(render_target *our_target)
 #define DSTSHIFT_B			0
 
 #include "rendersw.c"
+
+#endif

--- a/xcode/MAME4iOS/TVOptionsController.m
+++ b/xcode/MAME4iOS/TVOptionsController.m
@@ -42,9 +42,9 @@
     if ( section == kFilterSection ) {
         return 2;
     } else if ( section == kScreenSection ) {
-        return 7;
-    } else if ( section == kMiscSection ) {
         return 8;
+    } else if ( section == kMiscSection ) {
+        return 7;
     } else if ( section == kDefaultsSection ) {
         return 1;
     } else if ( section == kInputSection ) {
@@ -116,14 +116,17 @@
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.detailTextLabel.text = [Options.arrayColorSpace optionName:op.sourceColorSpace];
         } else if ( indexPath.row == 4 ) {
-            cell.textLabel.text = @"Keep Aspect Ratio";
-            cell.accessoryView = [self optionSwitchForKey:@"keepAspectRatioLand"];
-        } else if ( indexPath.row == 5 ) {
             cell.textLabel.text = @"Use Metal";
             cell.accessoryView = [self optionSwitchForKey:@"useMetal"];
+        } else if ( indexPath.row == 5 ) {
+            cell.textLabel.text = @"Keep Aspect Ratio";
+            cell.accessoryView = [self optionSwitchForKey:@"keepAspectRatioLand"];
         } else if ( indexPath.row == 6 ) {
             cell.textLabel.text = @"Integer Scaling Only";
             cell.accessoryView = [self optionSwitchForKey:@"integerScalingOnly"];
+        } else if ( indexPath.row == 7 ) {
+            cell.textLabel.text   = @"Force Pixel Aspect";
+            cell.accessoryView = [self optionSwitchForKey:@"forcepxa"];
         }
     } else if ( indexPath.section == kMiscSection ) {
         if ( indexPath.row == 0 ) {
@@ -148,9 +151,6 @@
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.detailTextLabel.text = [Options.arrayFSValue optionAtIndex:op.fsvalue];
         } else if ( indexPath.row == 6 ) {
-            cell.textLabel.text   = @"Force Pixel Aspect";
-            cell.accessoryView = [self optionSwitchForKey:@"forcepxa"];
-        } else if ( indexPath.row == 7 ) {
             cell.textLabel.text = @"Low Latency Audio";
             cell.accessoryView = [self optionSwitchForKey:@"lowlsound"];
         }

--- a/xcode/MAME4iOS/TVOptionsController.m
+++ b/xcode/MAME4iOS/TVOptionsController.m
@@ -112,7 +112,7 @@
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.detailTextLabel.text = [Options.arrayBorder optionName:op.borderLand];
         } else if ( indexPath.row == 3 ) {
-            cell.textLabel.text   = @"Source ColorSpace";
+            cell.textLabel.text   = @"ColorSpace";
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.detailTextLabel.text = [Options.arrayColorSpace optionName:op.sourceColorSpace];
         } else if ( indexPath.row == 4 ) {
@@ -130,26 +130,26 @@
             cell.textLabel.text   = @"Show FPS";
             cell.accessoryView = [self optionSwitchForKey:@"showFPS"];
         } else if ( indexPath.row == 1 ) {
+            cell.textLabel.text   = @"Show Info/Warnings";
+            cell.accessoryView = [self optionSwitchForKey:@"showINFO"];
+        } else if ( indexPath.row == 2 ) {
             cell.textLabel.text   = @"Emulated Resolution";
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.detailTextLabel.text = [Options.arrayEmuRes optionAtIndex:op.emures];
-        } else if ( indexPath.row == 2 ) {
+        } else if ( indexPath.row == 3 ) {
             cell.textLabel.text   = @"Emulated Speed";
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.detailTextLabel.text = [Options.arrayEmuSpeed optionAtIndex:op.emuspeed];
-        } else if ( indexPath.row == 3 ) {
+        } else if ( indexPath.row == 4 ) {
             cell.textLabel.text = @"Throttle";
             cell.accessoryView = [self optionSwitchForKey:@"throttle"];
-        } else if ( indexPath.row == 4 ) {
+        } else if ( indexPath.row == 5 ) {
             cell.textLabel.text = @"Frame Skip";
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.detailTextLabel.text = [Options.arrayFSValue optionAtIndex:op.fsvalue];
-        } else if ( indexPath.row == 5 ) {
-            cell.textLabel.text   = @"Fill Screen";
-            cell.accessoryView = [self optionSwitchForKey:@"forcepxa"];
         } else if ( indexPath.row == 6 ) {
-            cell.textLabel.text   = @"Show Info/Warnings";
-            cell.accessoryView = [self optionSwitchForKey:@"showINFO"];
+            cell.textLabel.text   = @"Force Pixel Aspect";
+            cell.accessoryView = [self optionSwitchForKey:@"forcepxa"];
         } else if ( indexPath.row == 7 ) {
             cell.textLabel.text = @"Low Latency Audio";
             cell.accessoryView = [self optionSwitchForKey:@"lowlsound"];
@@ -196,13 +196,13 @@
             [[self navigationController] pushViewController:listController animated:YES];
         }
     } else if ( indexPath.section == kMiscSection ) {
-        if ( indexPath.row == 1 ) {
+        if ( indexPath.row == 2 ) {
             ListOptionController *listController = [[ListOptionController alloc] initWithType:kTypeEmuRes list:Options.arrayEmuRes];
             [[self navigationController] pushViewController:listController animated:YES];
-        } else if ( indexPath.row == 2 ) {
+        } else if ( indexPath.row == 3 ) {
             ListOptionController *listController = [[ListOptionController alloc] initWithType:kTypeEmuSpeed list:Options.arrayEmuSpeed];
             [[self navigationController] pushViewController:listController animated:YES];
-        } else if ( indexPath.row == 4 ) {
+        } else if ( indexPath.row == 5 ) {
             ListOptionController *listController = [[ListOptionController alloc] initWithType:kTypeFSValue list:Options.arrayFSValue];
             [[self navigationController] pushViewController:listController animated:YES];
         }


### PR DESCRIPTION
This change does a few things.

* Overlay effects (CRT, Scanline, ...)
    - Works correctly when using artwork, effect will only overlay the game screen, not the bezels.
    - effect now handles the pixel/scanline size correctly when scaled.
    - Multiple screens (like cocktail layouts) will get overlay effects right.
    - Vector games will not get effects.

* Default Artwork size.
    - Artwork is shown at optimal size when `Emulated Resolution` is set to `Auto` (the default)

* OSD layer
    - new "call up" myosd_video_draw and iphone_DrawScreen
 