### PR TITLE
Build clean on Xcode 12

### DIFF
--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -50,7 +50,6 @@
 
 #if TARGET_OS_IOS
 #import <Intents/Intents.h>
-#import "HelpController.h"
 #import "OptionsController.h"
 #import "AnalogStick.h"
 #import "AnalogStick.h"
@@ -3795,7 +3794,7 @@ CGRect scale_rect(CGRect rect, CGFloat scale) {
     // add all the controllers with a extendedGamepad profile first
     for (GCController* controler in GCController.controllers) {
 #if TARGET_IPHONE_SIMULATOR // ignore the bogus controller in the simulator
-        if ([controler.vendorName isEqualToString:@"Generic Controller"])
+        if (controler.vendorName == nil || [controler.vendorName isEqualToString:@"Generic Controller"])
             continue;
 #endif
         if (controler.extendedGamepad != nil)

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -428,6 +428,7 @@ void myosd_set_game_info(myosd_game_info* game_info[], int game_count)
 
 - (void)startEmulation {
     NSParameterAssert(g_emulation_initiated == 0);
+    [self updateOptions];
     
     sharedInstance = self;
     

--- a/iOS/HelpController.h
+++ b/iOS/HelpController.h
@@ -44,7 +44,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface HelpController : UIViewController<UIWebViewDelegate>
+@interface HelpController : UIViewController
 
 - (id)initWithName:(NSString*)name title:(NSString*)title;
 - (void)loadHTML:(NSString*)name;

--- a/iOS/LayoutData.h
+++ b/iOS/LayoutData.h
@@ -72,7 +72,7 @@ enum LayoutSubtype
 
 @class EmulatorController;
 
-@interface LayoutData : NSObject <NSCoding> 
+@interface LayoutData : NSObject <NSSecureCoding> 
 {
    @public  int type;
    @public  int subtype;

--- a/iOS/LayoutData.m
+++ b/iOS/LayoutData.m
@@ -71,6 +71,10 @@
     return self;
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (id)initWithCoder:(NSCoder *)decoder {
     if (self = [super init]) {
         self.type = [decoder decodeIntForKey:@"type"];
@@ -218,18 +222,23 @@
     [filemgr removeItemAtPath:[LayoutData getLayoutFilePath] error:&error];
 }
 
-+(void)saveLayoutData:(NSMutableArray *)data {
-    
-    [NSKeyedArchiver archiveRootObject:data toFile:[LayoutData getLayoutFilePath]];
++(void)saveLayoutData:(NSMutableArray *)layoutData {
+//    [NSKeyedArchiver archiveRootObject:layoutData toFile:[LayoutData getLayoutFilePath]];
+    NSError* error = nil;
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:layoutData requiringSecureCoding:YES error:&error];
+    [data writeToFile:[LayoutData getLayoutFilePath] atomically:NO];
 }
 
 
 +(void)loadLayoutData:(EmulatorController *)emuController{
-    NSMutableArray *data = nil;
+    NSArray *data = nil;
+    NSError* error = nil;
     int i = 0;
-        
-    data = [NSKeyedUnarchiver unarchiveObjectWithFile:[LayoutData getLayoutFilePath]]; //devuelve un autorelease
     
+    data = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [LayoutData class]]]
+                                               fromData:[NSData dataWithContentsOfFile:[LayoutData getLayoutFilePath]]
+                                                  error:&error];
+        
     if(data != nil) {
         for(i=0; i<data.count ; i++)
         {
@@ -264,7 +273,7 @@
     }
 }
 
-+(void)printAsTextFileFormat:(NSMutableArray*)data emuController:(EmulatorController*)emuController {
++(void)printAsTextFileFormat:(NSArray*)data emuController:(EmulatorController*)emuController {
     NSMutableArray *layoutTextData = [[NSMutableArray alloc] init];
     NSArray<NSArray*> *fileDataLayoutElements = @[
                                      @[ @(kType_DPadRect), @(DPAD_DOWN_LEFT_RECT), @"//DownLeft"],    // 1

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
@@ -107,9 +107,7 @@
 		92A533D821EE601D0089FBB9 /* WebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 92A533D621EE601D0089FBB9 /* WebServer.m */; };
 		92A533D921EE601D0089FBB9 /* WebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 92A533D621EE601D0089FBB9 /* WebServer.m */; };
 		92A533DB21EEFDE20089FBB9 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92A533DA21EEFDE20089FBB9 /* CFNetwork.framework */; };
-		92A533DD21EEFE290089FBB9 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92A533DC21EEFE290089FBB9 /* MobileCoreServices.framework */; };
 		92A533DF21EEFE520089FBB9 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92A533DE21EEFE520089FBB9 /* CFNetwork.framework */; };
-		92A533E121EEFE570089FBB9 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92A533E021EEFE570089FBB9 /* MobileCoreServices.framework */; };
 		92B99F0F2022706600CC44E3 /* UIView+Toast.m in Sources */ = {isa = PBXBuildFile; fileRef = 92B99F0D2022706600CC44E3 /* UIView+Toast.m */; };
 		92D96574215B03E100EFE3AE /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 92D96573215B03E100EFE3AE /* libc++.tbd */; };
 		92ECB8F721EA985000D1E3D0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 92ECB8F621EA985000D1E3D0 /* Assets.xcassets */; };
@@ -176,6 +174,9 @@
 		EFA7570D2406D64600A02AAB /* SystemImage.m in Sources */ = {isa = PBXBuildFile; fileRef = EFA7570B2406D64600A02AAB /* SystemImage.m */; };
 		EFA7570E2406D64600A02AAB /* SystemImage.m in Sources */ = {isa = PBXBuildFile; fileRef = EFA7570B2406D64600A02AAB /* SystemImage.m */; };
 		EFA757222408488D00A02AAB /* iCadeControls.png in Resources */ = {isa = PBXBuildFile; fileRef = EFA757212408488D00A02AAB /* iCadeControls.png */; };
+		EFA98FB124A4E2BF007B6689 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA98FAE24A4CC49007B6689 /* CoreServices.framework */; };
+		EFA98FB324A4E2D5007B6689 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA98FB224A4E2D5007B6689 /* CoreServices.framework */; };
+		EFA98FB524A4F811007B6689 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA98FB424A4F810007B6689 /* WebKit.framework */; };
 		EFB3C6D624890F6200F44780 /* simpleCRT.metal in Sources */ = {isa = PBXBuildFile; fileRef = EFB3C6D524890F6200F44780 /* simpleCRT.metal */; };
 		EFB3C6D724890F6200F44780 /* simpleCRT.metal in Sources */ = {isa = PBXBuildFile; fileRef = EFB3C6D524890F6200F44780 /* simpleCRT.metal */; };
 		EFB3C6DD248C33DF00F44780 /* InfoHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = EFB3C6DB248C33DF00F44780 /* InfoHUD.m */; };
@@ -414,6 +415,9 @@
 		EFA7570B2406D64600A02AAB /* SystemImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SystemImage.m; sourceTree = "<group>"; };
 		EFA7570C2406D64600A02AAB /* SystemImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemImage.h; sourceTree = "<group>"; };
 		EFA757212408488D00A02AAB /* iCadeControls.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = iCadeControls.png; sourceTree = "<group>"; };
+		EFA98FAE24A4CC49007B6689 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
+		EFA98FB224A4E2D5007B6689 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS14.0.sdk/System/Library/Frameworks/CoreServices.framework; sourceTree = DEVELOPER_DIR; };
+		EFA98FB424A4F810007B6689 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		EFB3C6D524890F6200F44780 /* simpleCRT.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = simpleCRT.metal; sourceTree = "<group>"; };
 		EFB3C6DB248C33DF00F44780 /* InfoHUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InfoHUD.m; sourceTree = "<group>"; };
 		EFB3C6DC248C33DF00F44780 /* InfoHUD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InfoHUD.h; sourceTree = "<group>"; };
@@ -450,8 +454,8 @@
 				E9856CF023C9A7C50071666D /* MultipeerConnectivity.framework in Frameworks */,
 				EF27F36A23F7475100B1E50A /* libcompression.tbd in Frameworks */,
 				EFF9F82D24707EEA00DDA88C /* Metal.framework in Frameworks */,
+				EFA98FB124A4E2BF007B6689 /* CoreServices.framework in Frameworks */,
 				EFF9F827246EE30200DDA88C /* IntentsUI.framework in Frameworks */,
-				92A533DD21EEFE290089FBB9 /* MobileCoreServices.framework in Frameworks */,
 				92A533DB21EEFDE20089FBB9 /* CFNetwork.framework in Frameworks */,
 				92D96574215B03E100EFE3AE /* libc++.tbd in Frameworks */,
 				925ABCE51E46DD6E00997182 /* libmamearm64.a in Frameworks */,
@@ -461,6 +465,7 @@
 				925ABCBB1E46DCC500997182 /* CoreFoundation.framework in Frameworks */,
 				925ABCBC1E46DCC500997182 /* AudioToolbox.framework in Frameworks */,
 				925ABCBD1E46DCC500997182 /* QuartzCore.framework in Frameworks */,
+				EFA98FB524A4F811007B6689 /* WebKit.framework in Frameworks */,
 				EFA7570A2405BA0200A02AAB /* AVFoundation.framework in Frameworks */,
 				925ABCBE1E46DCC500997182 /* UIKit.framework in Frameworks */,
 				925ABCC01E46DCC500997182 /* Foundation.framework in Frameworks */,
@@ -474,7 +479,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				92A533E121EEFE570089FBB9 /* MobileCoreServices.framework in Frameworks */,
 				92A533DF21EEFE520089FBB9 /* CFNetwork.framework in Frameworks */,
 				92ECB91021EA99B600D1E3D0 /* GameKit.framework in Frameworks */,
 				92ECB90E21EA99A200D1E3D0 /* CoreGraphics.framework in Frameworks */,
@@ -486,6 +490,7 @@
 				EFA757082405B9EA00A02AAB /* AVFoundation.framework in Frameworks */,
 				92ECB90421EA997A00D1E3D0 /* GameController.framework in Frameworks */,
 				92ECB90121EA993E00D1E3D0 /* libc++.tbd in Frameworks */,
+				EFA98FB324A4E2D5007B6689 /* CoreServices.framework in Frameworks */,
 				92ECB8FF21EA992100D1E3D0 /* libmamearm64-tvos.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -679,6 +684,9 @@
 		CEE680881635BA7000051BC2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				EFA98FB424A4F810007B6689 /* WebKit.framework */,
+				EFA98FAE24A4CC49007B6689 /* CoreServices.framework */,
+				EFA98FB224A4E2D5007B6689 /* CoreServices.framework */,
 				EFF9F82C24707EE900DDA88C /* Metal.framework */,
 				EFF9F82E24707EF700DDA88C /* Metal.framework */,
 				EFF9F826246EE30200DDA88C /* IntentsUI.framework */,
@@ -903,7 +911,7 @@
 		CEE6807C1635BA6F00051BC2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = Seleuco;
 				TargetAttributes = {
 					925ABCA41E46DCC500997182 = {
@@ -1193,7 +1201,7 @@
 				);
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "MAME4iOS/MAME4iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../..",
@@ -1225,7 +1233,7 @@
 				GCC_PREFIX_HEADER = "MAME4iOS/MAME4iOS-Prefix.pch";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "MAME4iOS/MAME4iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../..",
@@ -1394,6 +1402,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1403,6 +1412,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Yoshinobu Sugawara (R72X3BF4KE)";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1418,7 +1428,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				MTL_LANGUAGE_REVISION = UseDeploymentTarget;
@@ -1448,6 +1458,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1465,7 +1476,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				MTL_LANGUAGE_REVISION = UseDeploymentTarget;

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/xcshareddata/xcschemes/MAME tvOS Debug.xcscheme
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/xcshareddata/xcschemes/MAME tvOS Debug.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "92ECB8EA21EA984D00D1E3D0"
-            BuildableName = "MAME4tvOS.app"
-            BlueprintName = "MAME tvOS"
-            ReferencedContainer = "container:MAME4iOS.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/xcshareddata/xcschemes/MAME tvOS Release.xcscheme
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/xcshareddata/xcschemes/MAME tvOS Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "92ECB8EA21EA984D00D1E3D0"
-            BuildableName = "MAME4tvOS.app"
-            BlueprintName = "MAME tvOS"
-            ReferencedContainer = "container:MAME4iOS.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/xcshareddata/xcschemes/MAME4iOS 64-bit Debug.xcscheme
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/xcshareddata/xcschemes/MAME4iOS 64-bit Debug.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "925ABCA41E46DCC500997182"
-            BuildableName = "MAME4iOS.app"
-            BlueprintName = "MAME4iOS 64-bit"
-            ReferencedContainer = "container:MAME4iOS.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/xcshareddata/xcschemes/MAME4iOS 64-bit Release.xcscheme
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/xcshareddata/xcschemes/MAME4iOS 64-bit Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "925ABCA41E46DCC500997182"
-            BuildableName = "MAME4iOS.app"
-            BlueprintName = "MAME4iOS 64-bit"
-            ReferencedContainer = "container:MAME4iOS.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>

--- a/xcode/MAME4iOS/MetalView.m
+++ b/xcode/MAME4iOS/MetalView.m
@@ -291,23 +291,29 @@
 -(void)drawEnd {
     assert(_drawable != nil);
     NSArray* buffers = _vertex_buffer_list;
-    __weak typeof(self) weakSelf = self;
+    __weak typeof(self) _self = self;
     BOOL externalDisplay = _externalDisplay;
     [_buffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
-        [weakSelf returnBuffers:buffers];
+        [_self returnBuffers:buffers];
         if (externalDisplay)
-            [weakSelf updateFPS:CACurrentMediaTime()];
+            [_self updateFPS:CACurrentMediaTime()];
     }];
+#if !TARGET_OS_SIMULATOR
     if (!externalDisplay) {
         [_drawable addPresentedHandler:^(id<MTLDrawable> drawable) {
-            [weakSelf updateFPS:drawable.presentedTime];
+            [_self updateFPS:drawable.presentedTime];
         }];
     }
+#endif
     [_encoder endEncoding];
+#if !TARGET_OS_SIMULATOR
     if (_preferredFramesPerSecond != 0 && _preferredFramesPerSecond * 2 <= _maximumFramesPerSecond && _layer.maximumDrawableCount == 3)
         [_buffer presentDrawable:_drawable afterMinimumDuration:1.0/_preferredFramesPerSecond];
     else
         [_buffer presentDrawable:_drawable];
+#else
+    [_buffer presentDrawable:_drawable];
+#endif
     [_buffer commit];
     _drawable = nil;
     _buffer = nil;


### PR DESCRIPTION
changed deployment target from iOS 11 -> iOS 12
changed use of MobileCoreServices to CoreServices.
UIWebView deprecated, converted to  WKWebView.
NSKeyedArchiver deprecation.

NOTE in order to Use CoreServices I had to up the deployment target to iOS 12.

ALSO added a call to updateOptions before we fire up the MAME thread, so key globals will be in a know state when the myosd audio system initializes.