### PR TITLE
iOS 14 Game Controller MENU button support.

### DIFF
--- a/iOS-res/Applications/MAME4iOS.app/help.md
+++ b/iOS-res/Applications/MAME4iOS.app/help.md
@@ -238,24 +238,47 @@ Some of the supported game controllers include, but are not limited to:
 * Xbox Wireless Controller with Bluetooth (Model 1708)
 * PlayStation DUALSHOCK®4 Wireless Controller
 * MFi (Made for iOS) Bluetooth controllers, like the SteelSeries Nimbus, Horipad Ultimate, and more may be supported.
+* XInput compatible controllers. (Pair via Options > Accessibility > Switch Control)
 * iCade
 * 8BitDo M30, Zero, and others
 * Steam Game Controllers
 * iMpulse
 
-Some of the new features added to the Controller experience include:
-
-* supports new controller types on iOS 13
-* new buttons (MENU, OPTIONS) on iOS 13+
-* you can now navigate a iOS Alert.
-  - dpad up/down move the current selection
-  - **A** - select the currently selected item.
-  - **B** - cancel the Alert
-
 To start playing a game using a controller, do one of the following.
-* hit the OPTIONS button (this will add a Coin and Start)
-* hit MENU and select "Coin + Start".
-* hit MENU+L1 to add a Coin, then hit MENU+R1 to Start.
+* hit MENU and select `Coin + Start` or `1 Player Start`
+* hit MENU+L1 to add a Coin, then hit MENU+R1 to Start. (iOS 13)
+* hit SELECT, then START (iOS 14+)
+
+## Xbox Controller (on iOS 14+)
+
+| | |  
+-|-
+`VIEW`     |SELECT                
+`GUIDE`           |MAME4iOS MENU   
+`MENU`     |START              
+
+## Xbox Controller (on iOS 13)
+
+| | |  
+-|-
+`VIEW`     |SELECT + START                
+`MENU`     |MAME4iOS MENU              
+
+## Playstation Dualshock (on iOS 14+)
+
+| | |  
+-|-
+`SHARE`     |SELECT                
+`PS Button`           |MAME4iOS MENU   
+`OPTIONS`     |START      
+
+## Playstation Dualshock (on iOS 13)
+
+| | |  
+-|-
+`SHARE`     |SELECT + START               
+`OPTIONS`     |MAME4iOS MENU       
+
 
 ## Steam Game Controlers
 
@@ -263,7 +286,16 @@ To start playing a game using a controller, do one of the following.
 
 To use a Steam Controller, make sure it is updated to BLE Firmware, and it paired with iOS device, see [here](https://support.steampowered.com/kb_article.php?ref=7728-QESJ-4420).
 
-## MENU/OPTION button on game controllers
+Steam Controller Buttons
+
+| | |  
+-|-
+`BACK`     |SELECT                 
+`STEAM Button`           |MAME4iOS MENU   
+`START`     |START              
+
+
+## MENU button on game controllers
 
 | | |  
 -|-
@@ -276,11 +308,8 @@ MENU+X       |Exit Game
 MENU+B       |Open MAME menu   
 MENU+A       |Load State  X (slot1) or Y (slot 2)            
 MENU+Y       |Save State  X (slot1) or Y (slot 2)              
-OPTION         |Insert Coin and Start   
 
 **NOTE** on versions prior to iOS 13 only MiFi controllers are reconized and when doing multiple button combinations the secondary button must be pressed first.  For example to insert a coin hold down L1 and hit MENU.  on iOS 13+ you can hold MENU and then hit L1.
-
-**NOTE** you can also use OPTION as a modifier, for example either MENU+L1 or OPTION+L1 will insert a coin.
 
 ## Multiplayer game start using game controllers
 

--- a/iOS-res/Applications/MAME4iOS.app/whatsnew.md
+++ b/iOS-res/Applications/MAME4iOS.app/whatsnew.md
@@ -1,5 +1,8 @@
 <img src="mame_logo.png" width="60%">
 
+# Version 2020.13
+* Support for Xbox `GUIDE`, DualShock `PS`, and Steam `STEAM` buttons on iOS 14.
+
 # Version 2020.12
 * `Metal` frame-skip updates and fixes.
 * Updated the `lineTron` vector shader.

--- a/iOS-res/Applications/MAME4iOS.app/whatsnew.md
+++ b/iOS-res/Applications/MAME4iOS.app/whatsnew.md
@@ -1,14 +1,12 @@
 <img src="mame_logo.png" width="60%">
 
-# Version 2020.13
-* Support for Xbox `GUIDE`, DualShock `PS`, and Steam `STEAM` buttons on iOS 14.
-
 # Version 2020.12
 * `Metal` frame-skip updates and fixes.
 * Updated the `lineTron` vector shader.
 * The HUD will honor the system DynamicType size.
 * PINCH and ZOOM to resize the HUD to exacly the size you want.
 * set MAME pause_brightness to 1.0
+* Support for Xbox `GUIDE`, DualShock `PS`, and Steam `STEAM` buttons on iOS 14.
 
 # Version 2020.11
 * Added new Vector Shader category for Vector games on both iOS and tvOS.

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -1052,9 +1052,23 @@ void mame_state(int load_save, int slot)
 
 - (void)handle_MENU
 {
+    // get input from all DPADs
     unsigned long pad_status = myosd_pad_status | myosd_joy_status[0] | myosd_joy_status[1] | myosd_joy_status[2] | myosd_joy_status[3];
-    
+
 #if TARGET_OS_IOS   // NOT needed on tvOS it handles it with the focus engine
+
+    // get input from left and right joystick #1
+    static NSTimeInterval g_last_input_time;
+    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    if (now - g_last_input_time > 0.250 && (pad_status & (MYOSD_UP|MYOSD_DOWN|MYOSD_LEFT|MYOSD_RIGHT)) == 0) {
+        if (round(joy_analog_y[0][0] * 1000.0) / 1000.0 == +1.0 || round(joy_analog_y[0][1] * 1000.0) / 1000.0 == +1.0)
+            pad_status |= MYOSD_UP;
+        if (round(joy_analog_y[0][0] * 1000.0) / 1000.0 == -1.0 || round(joy_analog_y[0][1] * 1000.0) / 1000.0 == -1.0)
+            pad_status |= MYOSD_DOWN;
+        if  (pad_status & (MYOSD_UP|MYOSD_DOWN|MYOSD_LEFT|MYOSD_RIGHT))
+            g_last_input_time = now;
+    }
+    
     UIViewController* viewController = [self presentedViewController];
     
     if ([viewController isKindOfClass:[UINavigationController class]])
@@ -1064,8 +1078,6 @@ void mame_state(int load_save, int slot)
     if ([viewController isKindOfClass:[UIAlertController class]])
     {
         UIAlertController* alert = (UIAlertController*)viewController;
-
-        unsigned long pad_status = myosd_pad_status | myosd_joy_status[0] | myosd_joy_status[1];
 
         if (pad_status & MYOSD_A)
             [alert dismissWithDefault];

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -82,6 +82,13 @@
 #import "SystemImage.h"
 #import "SteamController.h"
 
+// declare these selectors, so we can use them, and ARC wont complain
+#ifndef __IPHONE_14_0
+@interface NSObject()
+-(GCControllerButtonInput*)buttonHome;
+@end
+#endif
+
 #define DebugLog 0
 #if DebugLog == 0
 #define NSLog(...) (void)0

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -1049,8 +1049,29 @@ void mame_state(int load_save, int slot)
     }];
 }
 
-// declare selector, never called.
-- (void)handle_MENU:(NSNumber*)status {}
+- (void)handle_MENU:(NSNumber*)status {
+    
+    // if we are showing an alert map controller input to the alert
+    UIAlertController* alert = (UIAlertController*)[self presentedViewController];
+
+    if ([alert isKindOfClass:[UIAlertController class]])
+    {
+        unsigned long pad_status = [status longValue];
+
+        if (pad_status & (MYOSD_A|MYOSD_SELECT))
+            [alert dismissWithDefault];
+        if (pad_status & MYOSD_B)
+            [alert dismissWithCancel];
+        if (pad_status & MYOSD_Y)
+            [alert dismissWithTitle:@"Ⓨ"];
+        if (pad_status & MYOSD_X)
+            [alert dismissWithTitle:@"Ⓧ"];
+        if (pad_status & MYOSD_UP)
+            [alert moveDefaultAction:-1];
+        if (pad_status & MYOSD_DOWN)
+            [alert moveDefaultAction:+1];
+    }
+}
 
 - (void)handle_MENU
 {
@@ -1084,31 +1105,12 @@ void mame_state(int load_save, int slot)
                 g_last_input_time = now;
         }
 
-        // if we are showing an alert map controller input to the alert
-        if ([viewController isKindOfClass:[UIAlertController class]])
-        {
-            UIAlertController* alert = (UIAlertController*)viewController;
-
-            if (pad_status & (MYOSD_A|MYOSD_SELECT))
-                [alert dismissWithDefault];
-            if (pad_status & MYOSD_B)
-                [alert dismissWithCancel];
-            if (pad_status & MYOSD_Y)
-                [alert dismissWithTitle:@"Ⓨ"];
-            if (pad_status & MYOSD_X)
-                [alert dismissWithTitle:@"Ⓧ"];
-            if (pad_status & MYOSD_UP)
-                [alert moveDefaultAction:-1];
-            if (pad_status & MYOSD_DOWN)
-                [alert moveDefaultAction:+1];
-            return;
-        }
-        
         // if we are showing some other UI, give it a chance to handle input.
         if ([viewController respondsToSelector:@selector(handle_MENU:)])
             [viewController performSelector:@selector(handle_MENU:) withObject:@(pad_status)];
+        else
+            [self handle_MENU:@(pad_status)];
         
-        // if we are showing something else, just ignore.
         return;
     }
 

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -1768,7 +1768,7 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
             g_last_input_time = now;
     }
 
-    if (pad_status & MYOSD_A)
+    if (pad_status & (MYOSD_A|MYOSD_SELECT|MYOSD_START))
         [self onCommandSelect];
     if (pad_status & MYOSD_UP)
         [self onCommandUp];

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -1749,7 +1749,24 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
 // called when input happens on a gamecontroller, keyboard, or touch screen
 // check for input related to moving and selecting.
 -(void)handle_MENU {
+    // get input from all DPADs
     unsigned long pad_status = myosd_pad_status | myosd_joy_status[0] | myosd_joy_status[1];
+    
+    // get input from left and right joystick #1
+    static NSTimeInterval g_last_input_time;
+    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    if (now - g_last_input_time > 0.250 && (pad_status & (MYOSD_UP|MYOSD_DOWN|MYOSD_LEFT|MYOSD_RIGHT)) == 0) {
+        if (round(joy_analog_y[0][0] * 1000.0) / 1000.0 == +1.0 || round(joy_analog_y[0][1] * 1000.0) / 1000.0 == +1.0)
+            pad_status |= MYOSD_UP;
+        if (round(joy_analog_y[0][0] * 1000.0) / 1000.0 == -1.0 || round(joy_analog_y[0][1] * 1000.0) / 1000.0 == -1.0)
+            pad_status |= MYOSD_DOWN;
+        if (round(joy_analog_x[0][0] * 1000.0) / 1000.0 == +1.0 || round(joy_analog_x[0][1] * 1000.0) / 1000.0 == +1.0)
+            pad_status |= MYOSD_RIGHT;
+        if (round(joy_analog_x[0][0] * 1000.0) / 1000.0 == -1.0 || round(joy_analog_x[0][1] * 1000.0) / 1000.0 == -1.0)
+            pad_status |= MYOSD_LEFT;
+        if  (pad_status & (MYOSD_UP|MYOSD_DOWN|MYOSD_LEFT|MYOSD_RIGHT))
+            g_last_input_time = now;
+    }
 
     if (pad_status & MYOSD_A)
         [self onCommandSelect];

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -1748,26 +1748,12 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
 
 // called when input happens on a gamecontroller, keyboard, or touch screen
 // check for input related to moving and selecting.
--(void)handle_MENU {
+-(void)handle_MENU:(NSNumber*)status
+{
     // get input from all DPADs
-    unsigned long pad_status = myosd_pad_status | myosd_joy_status[0] | myosd_joy_status[1];
+    unsigned long pad_status = [status longValue];
     
     // get input from left and right joystick #1
-    static NSTimeInterval g_last_input_time;
-    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
-    if (now - g_last_input_time > 0.250 && (pad_status & (MYOSD_UP|MYOSD_DOWN|MYOSD_LEFT|MYOSD_RIGHT)) == 0) {
-        if (round(joy_analog_y[0][0] * 1000.0) / 1000.0 == +1.0 || round(joy_analog_y[0][1] * 1000.0) / 1000.0 == +1.0)
-            pad_status |= MYOSD_UP;
-        if (round(joy_analog_y[0][0] * 1000.0) / 1000.0 == -1.0 || round(joy_analog_y[0][1] * 1000.0) / 1000.0 == -1.0)
-            pad_status |= MYOSD_DOWN;
-        if (round(joy_analog_x[0][0] * 1000.0) / 1000.0 == +1.0 || round(joy_analog_x[0][1] * 1000.0) / 1000.0 == +1.0)
-            pad_status |= MYOSD_RIGHT;
-        if (round(joy_analog_x[0][0] * 1000.0) / 1000.0 == -1.0 || round(joy_analog_x[0][1] * 1000.0) / 1000.0 == -1.0)
-            pad_status |= MYOSD_LEFT;
-        if  (pad_status & (MYOSD_UP|MYOSD_DOWN|MYOSD_LEFT|MYOSD_RIGHT))
-            g_last_input_time = now;
-    }
-
     if (pad_status & (MYOSD_A|MYOSD_SELECT|MYOSD_START))
         [self onCommandSelect];
     if (pad_status & MYOSD_UP)

--- a/xcode/MAME4iOS/SteamController/SteamController.h
+++ b/xcode/MAME4iOS/SteamController/SteamController.h
@@ -195,6 +195,8 @@ will be sent as soon as it's touched. Defaults to `YES`. */
 @property (nonatomic, readonly, nullable) GCControllerButtonInput *steamBackButton;
 /// The right pointing button to the right of the Steam button.
 @property (nonatomic, readonly, nullable) GCControllerButtonInput *steamForwardButton;
+/// The Steam button.
+@property (nonatomic, readonly, nullable) GCControllerButtonInput *steamSteamButton;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/xcode/MAME4iOS/SteamController/SteamController.m
+++ b/xcode/MAME4iOS/SteamController/SteamController.m
@@ -327,7 +327,8 @@ static CBUUID *SteamControllerReportCharacteristicUUID;
     snapshot.rightThumbstickButton = (state.buttons & SteamControllerButtonRightGrip);
     snapshot.steamBackButton = (state.buttons & SteamControllerButtonBack);
     snapshot.steamForwardButton = (state.buttons & SteamControllerButtonForward);
-    
+    snapshot.steamSteamButton = (state.buttons & SteamControllerButtonSteam);
+
     BOOL hasUpdatedPads[] = {
         [SteamControllerMappingDPad] = NO,
         [SteamControllerMappingLeftThumbstick] = NO,
@@ -372,7 +373,11 @@ static CBUUID *SteamControllerReportCharacteristicUUID;
     GSEventResetIdleTimer();
 #endif
     
-    if (hasButtons && (state.buttons & SteamControllerButtonSteam)) {
+    if (_steamButtonCombinationHandler == nil) {
+        // Update client
+        extendedGamepad.state = snapshot;
+    }
+    else if (hasButtons && (state.buttons & SteamControllerButtonSteam)) {
         // Handle steam button combos
         handledSteamCombos |= [self handleSteamButtonCombos:(state.buttons & ~SteamControllerButtonSteam)];
     } else if (hasButtons && (previousButtons & SteamControllerButtonSteam)) {
@@ -495,6 +500,10 @@ NSString* NSStringFromSteamControllerButton(SteamControllerButton button) {
 }
 
 - (GCControllerButtonInput *)steamForwardButton {
+    return nil;
+}
+
+- (GCControllerButtonInput *)steamSteamButton {
     return nil;
 }
 

--- a/xcode/MAME4iOS/SteamController/SteamControllerExtendedGamepad.h
+++ b/xcode/MAME4iOS/SteamController/SteamControllerExtendedGamepad.h
@@ -49,6 +49,7 @@ typedef struct {
 #pragma mark - Steam Controller
     BOOL steamBackButton;
     BOOL steamForwardButton;
+    BOOL steamSteamButton;
 } SteamControllerExtendedGamepadSnapshotData;
 #pragma pack(pop)
 
@@ -71,8 +72,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) SteamControllerButtonInput *rightThumbstickButton;
 @property (nonatomic, readonly, nullable) SteamControllerButtonInput *buttonOptions;
 @property (nonatomic, readonly, nullable) SteamControllerButtonInput *buttonMenu;
+@property (nonatomic, readonly, nullable) SteamControllerButtonInput *buttonHome;
 @property (nonatomic, readonly, nullable) SteamControllerButtonInput *steamBackButton;
 @property (nonatomic, readonly, nullable) SteamControllerButtonInput *steamForwardButton;
+@property (nonatomic, readonly, nullable) SteamControllerButtonInput *steamSteamButton;
 @property (nonatomic, assign) SteamControllerExtendedGamepadSnapshotData state;
 
 - (instancetype)initWithController:(SteamController*)controller;

--- a/xcode/MAME4iOS/SteamController/SteamControllerExtendedGamepad.m
+++ b/xcode/MAME4iOS/SteamController/SteamControllerExtendedGamepad.m
@@ -17,7 +17,7 @@
     SteamControllerButtonInput *leftThumbstickButton, *rightThumbstickButton;
     SteamControllerButtonInput *leftTrigger, *rightTrigger;
     SteamControllerButtonInput *buttonA, *buttonB, *buttonX, *buttonY;
-    SteamControllerButtonInput *steamBackButton, *steamForwardButton;
+    SteamControllerButtonInput *steamBackButton, *steamForwardButton, *steamSteamButton;
     __weak SteamController *steamController;
     SteamControllerExtendedGamepadSnapshotData state;
     GCExtendedGamepadValueChangedHandler valueChangedHandler;
@@ -28,7 +28,7 @@
 @synthesize leftTrigger, rightTrigger;
 @synthesize buttonA, buttonB, buttonX, buttonY;
 @synthesize leftThumbstickButton, rightThumbstickButton;
-@synthesize steamBackButton, steamForwardButton;
+@synthesize steamBackButton, steamForwardButton, steamSteamButton;
 @synthesize state;
 
 - (instancetype)initWithController:(SteamController *)controller {
@@ -62,6 +62,7 @@
         }
         steamBackButton = [[SteamControllerButtonInput alloc] initWithController:controller analog:NO];
         steamForwardButton = [[SteamControllerButtonInput alloc] initWithController:controller analog:NO];
+        steamSteamButton = [[SteamControllerButtonInput alloc] initWithController:controller analog:NO];
     }
     return self;
 }
@@ -105,6 +106,7 @@
     UpdateStateBool(rightThumbstickButton);
     UpdateStateBool(steamBackButton);
     UpdateStateBool(steamForwardButton);
+    UpdateStateBool(steamSteamButton);
 }
 
 - (void)didChangeValueForElement:(GCControllerElement*)element {
@@ -119,6 +121,10 @@
 
 - (SteamControllerButtonInput *)buttonMenu {
     return steamForwardButton;
+}
+
+- (SteamControllerButtonInput *)buttonHome {
+    return steamSteamButton;
 }
 
 - (void)setStateFromExtendedGamepad:(GCExtendedGamepad *)extendedGamepad {


### PR DESCRIPTION
iOS 14 gives us access to the `MENU` (aka `GUIDE` on Xbox, and `PS` button on DualShock)  
this PR adds support for this button, and updates the SteamController to add support for `STEAM` button.

**NOTE** this PR does *not* require Xcode 12, or iOS 14.

**NOTE** the `STEAM` button on the SteamController will work even on iOS 13, Xbox and DualShock will require iOS 14.