### PR TITLE
fix AltStore sideloading crash.

### DIFF
--- a/iOS/CGScreenView.m
+++ b/iOS/CGScreenView.m
@@ -354,10 +354,10 @@ static BOOL g_render_dump = 0;
     
     for (myosd_render_primitive* prim = prim_list; prim != NULL; prim = prim->next) {
         
-        assert(prim->type == RENDER_PRIMITIVE_LINE || prim->type == RENDER_PRIMITIVE_QUAD);
-        assert(prim->blendmode <= BLENDMODE_ADD);
-        assert(prim->texformat <= TEXFORMAT_YUY16);
-        assert(prim->unused == 0);
+        NSParameterAssert(prim->type == RENDER_PRIMITIVE_LINE || prim->type == RENDER_PRIMITIVE_QUAD);
+        NSParameterAssert(prim->blendmode <= BLENDMODE_ADD);
+        NSParameterAssert(prim->texformat <= TEXFORMAT_YUY16);
+        NSParameterAssert(prim->unused == 0);
 
         int blend = prim->blendmode;
         int fmt = prim->texformat;

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -352,7 +352,7 @@ void* app_Thread_Start(void* args)
 NSDictionary* load_category_ini()
 {
     FILE* file = fopen(get_documents_path("Category.ini"), "r");
-    assert(file != NULL);
+    NSCParameterAssert(file != NULL);
     
     if (file == NULL)
         return nil;
@@ -444,16 +444,16 @@ void myosd_set_game_info(myosd_game_info* game_info[], int game_count)
 - (NSString*)getButtonName:(int)i {
     static NSString* button_name[NUM_BUTTONS] = {@"A",@"B",@"Y",@"X",@"L1",@"R1",@"A+Y",@"A+X",@"B+Y",@"B+X",@"A+B",@"SELECT",@"START",@"EXIT",@"OPTION",@"STICK"};
     _Static_assert(NUM_BUTTONS == 16, "enum size change");
-    assert(i < NUM_BUTTONS);
+    NSParameterAssert(i < NUM_BUTTONS);
     return button_name[i];
 }
 - (CGRect)getButtonRect:(int)i {
-    assert(i < NUM_BUTTONS);
+    NSParameterAssert(i < NUM_BUTTONS);
     return rButton[i];
 }
 // called by the LayoutView editor (and internaly)
 - (void)setButtonRect:(int)i rect:(CGRect)rect {
-    assert(i < NUM_BUTTONS);
+    NSParameterAssert(i < NUM_BUTTONS);
     rInput[i] = rButton[i] = rect;
     
     _Static_assert(BTN_A==0 && BTN_R1== 5, "enum order change");
@@ -495,7 +495,7 @@ void myosd_set_game_info(myosd_game_info* game_info[], int game_count)
 }
 
 + (EmulatorController*)sharedInstance {
-    assert(sharedInstance != nil);
+    NSParameterAssert(sharedInstance != nil);
     return sharedInstance;
 }
 
@@ -1562,7 +1562,7 @@ static int gcd(int a, int b) {
 #endif
 
 -(void)updateFrameRate {
-    assert([NSThread isMainThread]);
+    NSParameterAssert([NSThread isMainThread]);
 
     NSUInteger frame_count = screenView.frameCount;
 
@@ -2053,7 +2053,7 @@ NSInteger g_mame_buttons_tick;              // ticks until we send next one
         
 static void push_mame_button(int player, int button)
 {
-    assert([NSThread isMainThread]);     // only add buttons from main thread
+    NSCParameterAssert([NSThread isMainThread]);     // only add buttons from main thread
     if (g_mame_buttons == nil) {
         g_mame_buttons = [[NSMutableArray alloc] init];
         g_mame_buttons_lock = [[NSLock alloc] init];
@@ -3332,7 +3332,7 @@ void myosd_handle_turbo() {
 - (void)loadLayout {
     
     CGSize windowSize = self.view.bounds.size;
-    assert(windowSize.width != 0.0 && windowSize.height != 0.0);
+    NSParameterAssert(windowSize.width != 0.0 && windowSize.height != 0.0);
     BOOL isPhone = [self isPhone];
 
     // set the background and view rects.
@@ -3857,7 +3857,7 @@ CGRect scale_rect(CGRect rect, CGFloat scale) {
         [self performSelectorOnMainThread:@selector(moveROMS) withObject:nil waitUntilDone:NO];
     }
     else {
-        assert(urls.count == 1);
+        NSParameterAssert(urls.count == 1);
         NSLog(@"EXPORT: %@", urls.firstObject);
     }
 }

--- a/iOS/MetalScreenView.m
+++ b/iOS/MetalScreenView.m
@@ -47,7 +47,7 @@
 #import "ColorSpace.h"
 
 #define DebugLog 0
-#if DebugLog == 0
+#if DebugLog == 0 || !defined(DEBUG)
 #define NSLog(...) (void)0
 #endif
 
@@ -277,9 +277,9 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
     // get the shader to use when drawing the SCREEN, default to the 3 entry in the list (simpleTron).
     NSString* screen_shader = _options[kScreenViewScreenShader] ?: kScreenViewShaderDefault;
 
-    assert([MetalScreenView.screenShaderList[0] isEqualToString:kScreenViewShaderDefault]);
-    assert([MetalScreenView.screenShaderList[1] isEqualToString:kScreenViewShaderNone]);
-    assert(MetalScreenView.screenShaderList.count > 2);
+    NSParameterAssert([MetalScreenView.screenShaderList[0] isEqualToString:kScreenViewShaderDefault]);
+    NSParameterAssert([MetalScreenView.screenShaderList[1] isEqualToString:kScreenViewShaderNone]);
+    NSParameterAssert(MetalScreenView.screenShaderList.count > 2);
     if ([screen_shader length] == 0 || [screen_shader isEqualToString:kScreenViewShaderDefault])
         screen_shader = split(MetalScreenView.screenShaderList[2], @":").lastObject;
 
@@ -291,9 +291,9 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
     // get the shader to use when drawing VECTOR lines, default to lineTron
     NSString* line_shader = _options[kScreenViewLineShader] ?: kScreenViewShaderDefault;
     
-    assert([MetalScreenView.lineShaderList[0] isEqualToString:kScreenViewShaderDefault]);
-    assert([MetalScreenView.lineShaderList[1] isEqualToString:kScreenViewShaderNone]);
-    assert(MetalScreenView.lineShaderList.count > 2);
+    NSParameterAssert([MetalScreenView.lineShaderList[0] isEqualToString:kScreenViewShaderDefault]);
+    NSParameterAssert([MetalScreenView.lineShaderList[1] isEqualToString:kScreenViewShaderNone]);
+    NSParameterAssert(MetalScreenView.lineShaderList.count > 2);
     if ([line_shader length] == 0 || [line_shader isEqualToString:kScreenViewShaderDefault])
         line_shader = split(MetalScreenView.lineShaderList[2], @":").lastObject;
 
@@ -342,7 +342,7 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 #pragma mark - LINE BUFFER
 
 - (void)saveLine:(myosd_render_primitive*) line {
-    assert(line->type == RENDER_PRIMITIVE_LINE);
+    NSParameterAssert(line->type == RENDER_PRIMITIVE_LINE);
     
     if (_line_buffer == NULL)
         _line_buffer = malloc(LINE_BUFFER_SIZE * sizeof(_line_buffer[0]));
@@ -390,9 +390,9 @@ static void load_texture_prim(id<MTLTexture> texture, myosd_render_primitive* pr
     NSUInteger width = texture.width;
     NSUInteger height = texture.height;
     
-    assert(texture.pixelFormat == MTLPixelFormatBGRA8Unorm);
-    assert(texture.width == prim->texture_width);
-    assert(texture.height == prim->texture_height);
+    NSCParameterAssert(texture.pixelFormat == MTLPixelFormatBGRA8Unorm);
+    NSCParameterAssert(texture.width == prim->texture_width);
+    NSCParameterAssert(texture.height == prim->texture_height);
 
     static char* texture_format_name[] = {"UNDEFINED", "PAL16", "PALA16", "555", "RGB", "ARGB", "YUV16"};
     texture.label = [NSString stringWithFormat:@"MAME %08lX:%d %dx%d %s", (NSUInteger)prim->texture_base, prim->texture_seqid, prim->texture_width, prim->texture_height, texture_format_name[prim->texformat]];
@@ -481,11 +481,11 @@ static void load_texture_prim(id<MTLTexture> texture, myosd_render_primitive* pr
         case TEXFORMAT_YUY16:
         {
             // this texture format is only used for AVI files and LaserDisc player!
-            assert(FALSE);
+            NSCParameterAssert(FALSE);
             break;
         }
         default:
-            assert(FALSE);
+            NSCParameterAssert(FALSE);
             break;
     }
     TIMER_STOP(texture_load);
@@ -658,7 +658,7 @@ static void load_texture_prim(id<MTLTexture> texture, myosd_render_primitive* pr
         }
         else {
             NSLog(@"Unknown RENDER_PRIMITIVE!");
-            assert(FALSE);  // bad primitive
+            NSParameterAssert(FALSE);  // bad primitive
         }
         
         if (prim->type == RENDER_PRIMITIVE_QUAD)

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -158,7 +158,7 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
     // on macOS shared container id must be <TEAMID>.<BUNDLE IDENTIFIER>
     return nil;
 #else
-    assert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count >= 3);
+    NSParameterAssert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count >= 3);
     NSArray* items = [NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."];
     // on iOS shared container must be group.<BUNDLE IDENTIFIER>
     NSString* name = [NSString stringWithFormat:@"group.%@.%@.%@", items[0], items[1], items[2]];
@@ -922,7 +922,7 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
 - (void) updateExternal {
 
     // copy data to shared container for Widget and TopShelf
-    assert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count >= 3);
+    NSParameterAssert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count >= 3);
     NSArray* items = [NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."];
     NSURL* sharedContainer = [NSFileManager.defaultManager containerURLForSecurityApplicationGroupIdentifier:[NSString stringWithFormat:@"group.%@.%@.%@", items[0], items[1], items[2]]];
     if (sharedContainer != nil) {

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -158,9 +158,10 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
     // on macOS shared container id must be <TEAMID>.<BUNDLE IDENTIFIER>
     return nil;
 #else
-    assert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count == 3);
+    assert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count >= 3);
+    NSArray* items = [NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."];
     // on iOS shared container must be group.<BUNDLE IDENTIFIER>
-    NSString* name = [NSString stringWithFormat:@"group.%@", NSBundle.mainBundle.bundleIdentifier];
+    NSString* name = [NSString stringWithFormat:@"group.%@.%@.%@", items[0], items[1], items[2]];
     return [[NSUserDefaults alloc] initWithSuiteName:name];
 #endif
 }
@@ -921,7 +922,9 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
 - (void) updateExternal {
 
     // copy data to shared container for Widget and TopShelf
-    NSURL* sharedContainer = [NSFileManager.defaultManager containerURLForSecurityApplicationGroupIdentifier:[NSString stringWithFormat:@"group.%@", NSBundle.mainBundle.bundleIdentifier]];
+    assert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count >= 3);
+    NSArray* items = [NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."];
+    NSURL* sharedContainer = [NSFileManager.defaultManager containerURLForSecurityApplicationGroupIdentifier:[NSString stringWithFormat:@"group.%@.%@.%@", items[0], items[1], items[2]]];
     if (sharedContainer != nil) {
         for (NSString* key in @[RECENT_GAMES_KEY, FAVORITE_GAMES_KEY]) {
             NSArray* games = ([NSUserDefaults.standardUserDefaults objectForKey:key] ?: @[]);

--- a/xcode/MAME4iOS/CloudSync.m
+++ b/xcode/MAME4iOS/CloudSync.m
@@ -58,15 +58,19 @@ static CKDatabase*     _database;
     return _status;
 }
 
++(NSString*)cloudIdentifer {
+    assert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count >= 3);
+    NSArray* items = [NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."];
+    return [NSString stringWithFormat:@"iCloud.%@.%@.%@", items[0], items[1], items[2]];
+}
+
 +(void)updateCloudStatus {
     
     if (_container == nil) {
-        assert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count == 3);
-        NSString* identifier = [NSString stringWithFormat:@"iCloud.%@", NSBundle.mainBundle.bundleIdentifier];
         @try {
             // **NOTE** CKContainer.defaultContainer will throw a uncatchable exception, dont use it.
             //_container = CKContainer.defaultContainer;
-            _container = [CKContainer containerWithIdentifier:identifier];
+            _container = [CKContainer containerWithIdentifier:[self cloudIdentifer]];
         }
         @catch (id exception) {
             NSLog(@"CLOUD STATUS: %@", exception);

--- a/xcode/MAME4iOS/CloudSync.m
+++ b/xcode/MAME4iOS/CloudSync.m
@@ -28,7 +28,7 @@
 #import "Alert.h"
 
 #define DebugLog 1
-#if DebugLog == 0 || DEBUG == 0
+#if DebugLog == 0 || !defined(DEBUG)
 #define NSLog(...) (void)0
 #endif
 
@@ -59,7 +59,7 @@ static CKDatabase*     _database;
 }
 
 +(NSString*)cloudIdentifer {
-    assert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count >= 3);
+    NSParameterAssert([NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."].count >= 3);
     NSArray* items = [NSBundle.mainBundle.bundleIdentifier componentsSeparatedByString:@"."];
     return [NSString stringWithFormat:@"iCloud.%@.%@.%@", items[0], items[1], items[2]];
 }
@@ -222,9 +222,9 @@ static int inSync = 0;
 static UIAlertController *progressAlert = nil;
 
 +(BOOL)startSync:(NSString*)title block:(dispatch_block_t)block {
-    assert(NSThread.isMainThread);
-    assert(_container != nil && _database != nil);
-    assert(inSync == 0);
+    NSParameterAssert(NSThread.isMainThread);
+    NSParameterAssert(_container != nil && _database != nil);
+    NSParameterAssert(inSync == 0);
     if (inSync != 0)
         return FALSE;
     inSync = 1;
@@ -253,7 +253,7 @@ static UIAlertController *progressAlert = nil;
 }
 
 +(void)stopSync {
-    assert(inSync != 0);
+    NSParameterAssert(inSync != 0);
     dispatch_async(dispatch_get_main_queue(), ^{
         EmulatorController* emuController = EmulatorController.sharedInstance;
         
@@ -293,7 +293,7 @@ static UIAlertController *progressAlert = nil;
 // MARK: ERROR HANDLING
 
 + (void)handleError:(NSError*)error error:(dispatch_block_t)error_block retry:(dispatch_block_t)retry_block {
-    assert(error != nil);
+    NSParameterAssert(error != nil);
     NSLog(@"ERROR: %@", error);
     // handle a iCloud [retry](https://developer.apple.com/documentation/cloudkit/ckerrorretryafterkey)
     if (retry_block != nil && [error.domain isEqualToString:CKErrorDomain]) {
@@ -325,7 +325,7 @@ static UIAlertController *progressAlert = nil;
 
 // get list of ROMs in the cloud
 +(NSArray*)getCloudFiles {
-    assert(!NSThread.isMainThread);
+    NSParameterAssert(!NSThread.isMainThread);
     NSMutableArray* records = [[NSMutableArray alloc] init];
     
     dispatch_group_t group = dispatch_group_create();
@@ -488,7 +488,7 @@ static UIAlertController *progressAlert = nil;
     [self updateSync:((double)index / files.count) text:file];
     
     NSString* path = [NSString stringWithUTF8String:get_documents_path(file.UTF8String)];
-    assert([NSFileManager.defaultManager fileExistsAtPath:path]);
+    NSParameterAssert([NSFileManager.defaultManager fileExistsAtPath:path]);
 
     // make new record with file data, recordID.recordName *must* be equal to kRecordName
     CKRecord* record = [[CKRecord alloc] initWithRecordType:kRecordType recordID:[[CKRecordID alloc] initWithRecordName:file]];

--- a/xcode/MAME4iOS/ColorSpace.m
+++ b/xcode/MAME4iOS/ColorSpace.m
@@ -59,7 +59,7 @@ CGColorSpaceRef ColorSpaceFromString(NSString* string) {
     }
 
     NSArray* values = [string componentsSeparatedByString:@","];
-    assert(values.count == 1 || values.count == 3 || values.count == 6 || values.count == 9 || values.count == 18);
+    NSCParameterAssert(values.count == 1 || values.count == 3 || values.count == 6 || values.count == 9 || values.count == 18);
 
     if ([string length] == 0 || [string isEqualToString:@"Default"] || [string isEqualToString:@"DeviceRGB"]) {
         // Default or None

--- a/xcode/MAME4iOS/ImageCache.m
+++ b/xcode/MAME4iOS/ImageCache.m
@@ -264,7 +264,7 @@ static ImageCache* sharedInstance = nil;
 
 static CGColorRef blend(CGColorRef c0, CGColorRef c1, CGFloat f)
 {
-    assert(CGColorGetColorSpace(c0) == CGColorGetColorSpace(c1));
+    NSCParameterAssert(CGColorGetColorSpace(c0) == CGColorGetColorSpace(c1));
     
     const CGFloat* cc0 = CGColorGetComponents(c0);
     const CGFloat* cc1 = CGColorGetComponents(c1);

--- a/xcode/MAME4iOS/InfoHUD.m
+++ b/xcode/MAME4iOS/InfoHUD.m
@@ -347,7 +347,7 @@
 }
 
 - (void)addButton:(id)item color:(UIColor*)color handler:(void (^)(void))handler {
-    assert([item isKindOfClass:[NSString class]] || [item isKindOfClass:[UIImage class]]);
+    NSParameterAssert([item isKindOfClass:[NSString class]] || [item isKindOfClass:[UIImage class]]);
     UISegmentedControl* seg = [self makeSegmentedControl:@[item] handler:^(NSUInteger button) {
         handler();
     }];

--- a/xcode/MAME4iOS/MetalView.m
+++ b/xcode/MAME4iOS/MetalView.m
@@ -15,7 +15,7 @@
 #endif
 
 #define DebugLog 0
-#if DebugLog == 0
+#if DebugLog == 0 || !defined(DEBUG)
 #define NSLog(...) (void)0
 #endif
 
@@ -263,7 +263,7 @@ __attribute__((objc_direct_members))
 -(BOOL)drawBegin {
     
     // nested drawBegin, very BAD!
-    assert(_encoder == nil);
+    NSParameterAssert(_encoder == nil);
     if (_encoder != nil)
         return FALSE;
     
@@ -352,7 +352,7 @@ __attribute__((objc_direct_members))
 }
 
 -(void)drawEnd {
-    assert(_drawable != nil);
+    NSParameterAssert(_drawable != nil);
     NSArray* buffers = _vertex_buffer_list;
     __weak typeof(self) _self = self;
     BOOL externalDisplay = _externalDisplay;
@@ -401,7 +401,7 @@ __attribute__((objc_direct_members))
 #pragma mark - draw primitives
 
 -(void)drawPrim:(MTLPrimitiveType)type vertices:(Vertex2D*)vertices count:(NSUInteger)count {
-    assert(_encoder != nil);
+    NSParameterAssert(_encoder != nil);
 
     // if our buffer is full, get a new one.
     if (_vertex_buffer_base + count >= NUM_VERTEX) {
@@ -611,7 +611,7 @@ __attribute__((objc_direct_members))
         case UIImageOrientationDownMirrored:
         case UIImageOrientationLeftMirrored:
         case UIImageOrientationRightMirrored:
-            assert(FALSE);
+            NSParameterAssert(FALSE);
             break;
     }
 
@@ -651,7 +651,7 @@ __attribute__((objc_direct_members))
         case UIImageOrientationDownMirrored:
         case UIImageOrientationLeftMirrored:
         case UIImageOrientationRightMirrored:
-            assert(FALSE);
+            NSParameterAssert(FALSE);
             break;
     }
 
@@ -765,7 +765,7 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 ///                 named-variable=42.0 - a named variable with a default value.
 ///
 - (void)setShader:(Shader)shader {
-    assert(_encoder != nil);
+    NSParameterAssert(_encoder != nil);
     
     // fastest case, do nothing if we are setting the same shader again.
     if (_shader_current == shader || [_shader_current isEqualToString:shader])
@@ -808,7 +808,7 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
         frag = [_library newFunctionWithName:[NSString stringWithFormat:@"fragment_%@", shader_name]];
     
     if (frag == nil) {
-        assert(FALSE);
+        NSParameterAssert(FALSE);
         NSLog(@"SHADER NOT FOUND: %@, using default", shader_name);
         frag = [_library newFunctionWithName:@"fragment_default"];
     }
@@ -888,7 +888,7 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 
 // resolve nammed shader variables and send float(s) to fragment function
 - (void)setShaderParams:(NSArray*)params {
-    assert(_encoder != nil);
+    NSParameterAssert(_encoder != nil);
     
     if ([params count] == 0)
         return;
@@ -898,7 +898,7 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
     for (id param in params) {
         
         // just ignore too many params.
-        assert(count <= sizeof(float_params)/sizeof(float) - 16);
+        NSParameterAssert(count <= sizeof(float_params)/sizeof(float) - 16);
         if (count > sizeof(float_params)/sizeof(float) - 16)
             break;
         
@@ -908,11 +908,10 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
             val = _shader_variables[param];
             if (val == nil) {
                 NSLog(@"UNKNOWN SHADER VARIABLE '%@' for shader \"%@\"", param, _shader_current);
-                //assert(FALSE);
                 val = @(0);
             }
         }
-        assert([val isKindOfClass:[NSValue class]]);
+        NSParameterAssert([val isKindOfClass:[NSValue class]]);
 
         if ([val isKindOfClass:[NSNumber class]]) {
             float_params[count++] = [(id)val floatValue];
@@ -947,7 +946,7 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
         }
         else {
             NSLog(@"INVALID SHADER VARIABLE '%@' type=%s", param, [val objCType]);
-            assert(FALSE);
+            NSParameterAssert(FALSE);
         }
     }
     if (count & 1)
@@ -959,8 +958,8 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 - (void)setShaderVariablesInternal:(NSDictionary *)variables {
 #ifdef DEBUG
     for (NSString* key in variables.allKeys) {
-        assert([key isKindOfClass:[NSString class]]);
-        assert([variables[key] isKindOfClass:[NSValue class]]);
+        NSParameterAssert([key isKindOfClass:[NSString class]]);
+        NSParameterAssert([variables[key] isKindOfClass:[NSValue class]]);
     }
 #endif
     
@@ -1058,7 +1057,7 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
     if (texture == nil || texture.width != width || texture.height != height) {
         texture = [self textureWithFormat:format width:width height:height];
         texture.label = [NSString stringWithFormat:@"%08lX:%ld %ldx%ld", (NSUInteger)identifier, hash, width, height];
-        assert(texture != nil);
+        NSParameterAssert(texture != nil);
     }
     
     // call handler to fill the texture.
@@ -1083,8 +1082,8 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 ///    texture_load - callback used to load image data.
 ///
 -(void)setTexture:(NSUInteger)index texture:(void*)identifier hash:(NSUInteger)hash width:(NSUInteger)width height:(NSUInteger)height format:(MTLPixelFormat)format texture_load:(void (NS_NOESCAPE ^)(id<MTLTexture> texture))texture_load {
-    assert(_encoder != nil);
-    assert(texture_load != nil);
+    NSParameterAssert(_encoder != nil);
+    NSParameterAssert(texture_load != nil);
     id<MTLTexture> texture = [self getTexture:identifier hash:hash width:width height:height format:format texture_load:texture_load];
     [_encoder setFragmentTexture:texture atIndex:index];
 }
@@ -1092,8 +1091,8 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 #pragma mark - filter and address mode
 
 -(void)updateSamplerState {
-    assert(_texture_filter == MTLSamplerMinMagFilterNearest || _texture_filter == MTLSamplerMinMagFilterLinear);
-    assert(_texture_address_mode >= MTLSamplerAddressModeClampToEdge && _texture_address_mode <= MTLSamplerAddressModeClampToZero);
+    NSParameterAssert(_texture_filter == MTLSamplerMinMagFilterNearest || _texture_filter == MTLSamplerMinMagFilterLinear);
+    NSParameterAssert(_texture_address_mode >= MTLSamplerAddressModeClampToEdge && _texture_address_mode <= MTLSamplerAddressModeClampToZero);
     _Static_assert(MTLSamplerAddressModeClampToEdge == 0 && MTLSamplerAddressModeClampToZero == 4, "MTLSamplerAddressMode bad!");
     _Static_assert(MTLSamplerMinMagFilterNearest == 0 && MTLSamplerMinMagFilterLinear == 1, "MTLSamplerMinMagFilter bad!");
     _Static_assert(sizeof(_texture_sampler) / sizeof(_texture_sampler[0]) == 5*2, "_texture_sampler wrong size!");
@@ -1120,14 +1119,14 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 }
 
 -(void)setTextureFilter:(MTLSamplerMinMagFilter)filter {
-    assert(_texture_filter == MTLSamplerMinMagFilterNearest || _texture_filter == MTLSamplerMinMagFilterLinear);
+    NSParameterAssert(_texture_filter == MTLSamplerMinMagFilterNearest || _texture_filter == MTLSamplerMinMagFilterLinear);
     if (_texture_filter != filter) {
         _texture_filter = filter;
         [self updateSamplerState];
     }
 }
 -(void)setTextureAddressMode:(MTLSamplerAddressMode)mode {
-    assert(_texture_address_mode >= MTLSamplerAddressModeClampToEdge && _texture_address_mode <= MTLSamplerAddressModeClampToZero);
+    NSParameterAssert(_texture_address_mode >= MTLSamplerAddressModeClampToEdge && _texture_address_mode <= MTLSamplerAddressModeClampToZero);
     if (_texture_address_mode != mode) {
         _texture_address_mode = mode;
         [self updateSamplerState];
@@ -1148,8 +1147,8 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 ///    texture_load - callback used to load image data.
 ///
 -(void)setTexture:(NSUInteger)index texture:(void*)identifier hash:(NSUInteger)hash width:(NSUInteger)width height:(NSUInteger)height format:(MTLPixelFormat)format colorspace:(CGColorSpaceRef)colorspace texture_load:(void (NS_NOESCAPE ^)(id<MTLTexture> texture))texture_load {
-    assert(_encoder != nil);
-    assert(texture_load != nil);
+    NSParameterAssert(_encoder != nil);
+    NSParameterAssert(texture_load != nil);
     
 #if (TARGET_OS_SIMULATOR && TARGET_OS_TV)
     // no MetalPerformanceShaders in tvOS simulator!!!
@@ -1205,7 +1204,7 @@ static void texture_load_uiimage(id<MTLTexture> texture, UIImage* image) {
     
     CGColorSpaceRef colorSpace = CGImageGetColorSpace(image.CGImage);
 
-    assert(texture.pixelFormat == MTLPixelFormatRGBA8Unorm);
+    NSCParameterAssert(texture.pixelFormat == MTLPixelFormatRGBA8Unorm);
     uint32_t bitmapInfo = kCGImageAlphaPremultipliedLast;
     
     CGContextRef bitmap = CGBitmapContextCreate(bitmap_data, width, height, 8, width*4, colorSpace, bitmapInfo);

--- a/xcode/MAME4iOS/SkinManager.m
+++ b/xcode/MAME4iOS/SkinManager.m
@@ -119,7 +119,7 @@ static NSArray* g_skin_list;
 
         NSDate* custom_date = [[NSFileManager.defaultManager attributesOfItemAtPath:custom_path error:nil] fileModificationDate];
         NSDate* skin_date = [[NSFileManager.defaultManager attributesOfItemAtPath:path error:nil] fileModificationDate];
-        assert(skin_date != nil);
+        NSParameterAssert(skin_date != nil);
 
         if (custom_date != nil && [skin_date compare:custom_date] == NSOrderedDescending) {
             [self addInfo:[self loadData:@"skin.json" from:path]];
@@ -137,7 +137,7 @@ static NSArray* g_skin_list;
     
     // add our Default layout file in SKIN_1 last
     NSData* info = [NSData dataWithContentsOfFile:[NSString stringWithUTF8String:get_resource_path("SKIN_1/skin.json")]];
-    assert(info != nil || TARGET_OS_TV);
+    NSParameterAssert(info != nil || TARGET_OS_TV);
     [self addInfo:info];
     
     NSLog(@"SKIN: %@\n%@\n%@", name, _skin_paths, _skin_infos);
@@ -158,7 +158,7 @@ static NSArray* g_skin_list;
         
         if (![info isKindOfClass:[NSDictionary class]]) {
             NSLog(@"INVALID JSON: %@", error);
-            assert(FALSE);
+            NSParameterAssert(FALSE);
             return;
         }
         
@@ -310,7 +310,7 @@ BOOL UIImageIsBlank(UIImage* image) {
         for (NSString* key in [defaults[section] allKeys]) {
             NSString* keyPath = [NSString stringWithFormat:@"%@.%@", section, key];
             id value = [self valueForKeyPath:keyPath];
-            assert(value != nil);
+            NSParameterAssert(value != nil);
             if (isDefault || [section isEqualToString:@"info"] || ![value isEqual:[defaults valueForKeyPath:keyPath]])
                 [dict setValue:value forKeyPath:keyPath];
         }

--- a/xcode/MAME4iOS/Widget/Widget.swift
+++ b/xcode/MAME4iOS/Widget/Widget.swift
@@ -104,7 +104,7 @@ struct WidgetEntryView : View {
 
 @main
 struct Widget: SwiftUI.Widget {
-    let kind: String = Bundle.main.bundleIdentifier!
+    let kind = "QuickPlay"
     
     // we only want to allow a widget in the widget gallery if a shared group is properly configured.
     let showWidget = MameGameInfo.isSharedGroupSetup

--- a/xcode/MAME4iOS/Widget/Widget.swift
+++ b/xcode/MAME4iOS/Widget/Widget.swift
@@ -104,7 +104,7 @@ struct WidgetEntryView : View {
 
 @main
 struct Widget: SwiftUI.Widget {
-    let kind = "QuickPlay"
+    let kind = "MAME4iOS.QuickPlay"
     
     // we only want to allow a widget in the widget gallery if a shared group is properly configured.
     let showWidget = MameGameInfo.isSharedGroupSetup


### PR DESCRIPTION
AltStore (and maybe others) when sideloading will add TEAM ident to the end of our bundle identifier
change the code to handle bundle identifiers with more than three components correctly.