### PR TITLE
Game Controller cleanup...

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can upload ROMs to MAME on your AppleTV using a computer. After MAME starts,
 
 ## Game Controller Support
 
-Pair your MFI, Xbox, or Dual Shock controller with your iOS device, and it should 'just work'.
+Pair your MFi, Xbox, or Dual Shock controller with your iOS device, and it should 'just work'.
 Up to 4 controllers are supported.
 
 ### Hotkey combinations (while in-game)
@@ -145,8 +145,10 @@ The following hotkey combinations are supported:
 | | |  
 ---------------- |-------------
 MENU             |Open MAME4iOS MENU   
-MENU+L1       |Insert coin                 
-MENU+R1       |Start Game               
+MENU+L1       |Player 1 Coin                 
+MENU+R1       |Player 1 Start               
+MENU+L2       |Player 2 Coin                
+MENU+R2       |Player 2 Start               
 MENU+X          |Exit Game                 
 MENU+B          |Open MAME menu   
 MENU+A          |Load State                

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Even if you are not in the paid Apple Developer Program, you can sideload the ap
 
 MAME for tvOS support was added in early 2019, and it currently can run games has full native UI support and MFI controller support with most notably:
 
-- MFI controllers, Xbox One, PS4 DualShock, and Siri Remote suppor.
+- MFI controllers, Xbox One, PS4 DualShock, and Siri Remote support.
 
 ## Using MAME
 
@@ -110,8 +110,6 @@ When you start MAME4iOS, you are now presented with an updated and native iOS/tv
 
 - Onscreen D-Pad or MFI Controller D-Pad: Move through the menu
 - A Button: Start Game
-- X Button: Open Game Sub-menu: Add to Favorites or Remove Game
-- Y Button: Open the Settings menu (Apple TV only)
 
 ### In-Game
 
@@ -150,10 +148,11 @@ MENU+R1       |Player 1 Start
 MENU+L2       |Player 2 Coin                
 MENU+R2       |Player 2 Start               
 MENU+X          |Exit Game                 
-MENU+B          |Open MAME menu   
-MENU+A          |Load State                
-MENU+Y          |Save State                
-OPTION            |Insert Coin and Start   
+MENU+Y          |Open MAME menu   
+MENU+DOWN  |Save State ①               
+MENU+UP        |Load State ①                
+MENU+LEFT     |Save State ②                
+MENU+RIGHT  |Load State ②               
 
 ### Dual analog support
 
@@ -170,7 +169,7 @@ to start playing a game, hit MENU and select "Coin + Start" from the list.
 
     TRACKPAD MOVE   - emulate a dpad or joystick
     TRAKPAD CLICK   - A button
-    PLAY            - X button
+    PLAY            - B button
     MENU            - bring up the MAME4iOS menu
 
 ## Touch Screen Lightgun Support (new in 2018, iOS only)

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,3 +1,12 @@
+# Version 2021.4
+* Better support for MFi controllers.
+* Game Controllers with more than two menu buttons (Xbox, DualShock, Xinput, Nimbus+, new MFi)
+    - Left menu button is always `SELECT`
+    - Right menu button is always `START`
+    - `SELECT` + `START` will bring up MAME4iOS menu
+    - holding down `SELECT` or `START` will show a *quick help HUD*
+* on iOS 14+ (not on tvOS) the XBox `GUIDE` button, and the DualShock `PS` button can be used instead of `SELECT`+`START`
+
 # Version 2021.3
 * This is a Mac-only release that has all the updates to 2021.2 and supports both Intel and Apple Silicon Macs.
 

--- a/iOS-res/help.md
+++ b/iOS-res/help.md
@@ -113,7 +113,7 @@ The emulator controls are the following ones:
 
 **Fullscreen Stick Size** Lets you change the stick size (not DPAD) on lanscape or portrait fullscreen mode.
 
-**Nintendo Button Layout** if enabled the 🅐 🅑 and 🅧 🅨 buttons will be swapped to match a Nintendo layout.  This option has no effect on a custom layout, or a physical game controller.
+**Nintendo Button Layout** if enabled the 🅐 🅑 and 🅧 🅨 buttons will be swapped to match a Nintendo layout.  This option has no effect on a physical game controller.
 
 **External Controller** Enable external controller: iCade, iControlPad as iCade mode or iMpulse.
 
@@ -371,6 +371,10 @@ Thanks to Todd Laney for sending me patches, and Martijn Bosschaart who has supp
 ## iMpulse
 
 MAME4iOS works correctly out of the box for iMpulse, also has built-in support for local multiplayer (TwiMpulse). Anayway, if you need to redefine second player buttons, you should press coin (left shoulder button) before so MAME4iOS initializes second iMpulse controller.
+
+## XInput Controller
+
+If you have an XInput compatible controller, use `Settings` > `Accessibility` > `Switch Control` > `Switches` > `Bluetooth Devices` to pair controller, then use as normal in MAME4iOS.
 
 ## TV-OUT
 

--- a/iOS-res/help.md
+++ b/iOS-res/help.md
@@ -12,7 +12,7 @@ MAME4iOS Reloaded emulates arcade games supported by original MAME 0.139u1.
 
 This MAME4iOS version is targeted at 64bit devies (A7 or higher, iPhone 5s or later) , because it is based on a high specs 2010 PC MAME build. Anyway don't expect arcade games of the 90 to work at full speed. Some games are really bad optimized (like outrun or mk series). This is related to MAME build used, since it is targeted to high specs PC's as i said before. This version doesn't have an UML backend ARM dynamic recompiler, which means drivers based on high specs arcade CPUs won't be playable (it has not sense since this games will be slow in any case).
 
-**TIP** You can try to use speed hacks (this menu appears pressing `START` + `COIN` at the same time when you are gaming) to make playables some games like CPS3 ones.
+**TIP** You can try to use speed hacks from the `MAME Configure` menu to make playables some games like CPS3 ones.
 
 Said that, with a low end device, use at your own risk. I suggest you use iMAME4all (0.37b5) instead. Remember that games that can be emulated on both versions will run much faster on iMAME4all (0.37b5) than on MAME4iOS Reloaded (0.139u1), and will drain less battery.
 
@@ -246,7 +246,9 @@ we suppoprt a small subset of the keys supported by the command line MAME.
 
 ## Game Controlers
 
-<img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/HNKT2?wid=1144&hei=1144&fmt=jpeg&qlt=95&op_usm=0.5%2C0.5&.v=1573236530750" width=30%> <img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/HNKS2?wid=1144&hei=1144&fmt=jpeg&qlt=95&op_usm=0.5%2C0.5&.v=1573236454283" width=30%> <img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/HJ162?wid=1144&hei=1144&fmt=jpeg&qlt=95&op_usm=0.5%2C0.5&.v=1477094888716" width=30%>
+<div style="background:white">
+<img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/HJ162" width=25%><img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/HNKT2" width=25%><img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/HNKS2" width=25%><img src="https://images-na.ssl-images-amazon.com/images/I/81oyj8wrlCL._SL1500_.jpg" width=25%>
+</div>
 
 Some of the supported game controllers include, but are not limited to:
 * Xbox Wireless Controller with Bluetooth (Model 1708)
@@ -260,43 +262,43 @@ Some of the supported game controllers include, but are not limited to:
 
 To start playing a game using a controller, do one of the following.
 * hit MENU and select `Coin + Start` or `1 Player Start`
-* hit MENU+L1 to add a Coin, then hit MENU+R1 to Start. (iOS 13)
-* hit SELECT, then START (iOS 14+)
+* hit MENU+L1 to add a Coin, then hit MENU+R1 to Start.
+* hit SELECT, then START
 
-## Xbox Controller (on iOS 14+)
+## Xbox Controller
 
 | | |  
 -|-
 `VIEW`     |SELECT                
-`GUIDE`           |MAME4iOS MENU   
+`GUIDE`   |MAME4iOS MENU (on iOS 14+)  
 `MENU`     |START              
+`VIEW`+`MENU`|MAME4iOS MENU
 
-## Xbox Controller (on iOS 13)
-
-| | |  
--|-
-`VIEW`     |SELECT + START                
-`MENU`     |MAME4iOS MENU              
-
-## Playstation Dualshock (on iOS 14+)
+## Playstation Dualshock
 
 | | |  
 -|-
 `SHARE`     |SELECT                
-`PS Button`           |MAME4iOS MENU   
+`PS Button`           |MAME4iOS MENU  (iOS 14+)
 `OPTIONS`     |START      
+`SHARE`+`OPTIONS`|MAME4iOS MENU
 
-## Playstation Dualshock (on iOS 13)
+## SteelSeries Nimbus Controller (MFi)
 
 | | |  
 -|-
-`SHARE`     |SELECT + START               
-`OPTIONS`     |MAME4iOS MENU       
+`MENU`           |MAME4iOS MENU   
 
+## Nimbus+ Controller
+
+| | |  
+-|-
+`OPTIONS`     |SELECT                
+`HOME`           |MAME4iOS MENU (on iOS 14)   
+`MENU`           |START      
+`OPTIONS`+`MENU`|MAME4iOS MENU
 
 ## Steam Game Controlers
-
-<img src="https://images-na.ssl-images-amazon.com/images/I/81oyj8wrlCL._SL1500_.jpg" width=30%>
 
 To use a Steam Controller, make sure it is updated to BLE Firmware, and it paired with iOS device, see [here](https://support.steampowered.com/kb_article.php?ref=7728-QESJ-4420).
 
@@ -319,11 +321,13 @@ MENU+R1     |Player 1 Start
 MENU+L2     |Player 2 Coin                
 MENU+R2     |Player 2 Start               
 MENU+X       |Exit Game                 
-MENU+B       |Open MAME menu   
-MENU+A       |Load State  X (slot1) or Y (slot 2)            
-MENU+Y       |Save State  X (slot1) or Y (slot 2)              
+MENU+Y       |Open MAME menu   
+MENU+DOWN  |Save State ①               
+MENU+UP        |Load State ①                
+MENU+LEFT     |Save State ②                
+MENU+RIGHT  |Load State ②               
 
-**NOTE** on versions prior to iOS 13 only MiFi controllers are reconized and when doing multiple button combinations the secondary button must be pressed first.  For example to insert a coin hold down L1 and hit MENU.  on iOS 13+ you can hold MENU and then hit L1.
+**NOTE** when using a MFi controller on versions prior to iOS 13, and tvOS, when doing multiple button combinations the secondary button must be pressed first.  For example to insert a coin hold down L1 and hit MENU.  on iOS 13+ you can hold MENU and then hit L1.
 
 ## Multiplayer game start using game controllers
 
@@ -333,30 +337,32 @@ You can insert a COIN or do a START for another player from the main Game Contro
 
 | | |  
 -|-
-MENU+L1+UP     |Player 2 COIN           
-MENU+R1+UP     |Player 2 START
-MENU+L1+RIGHT     |Player 3 COIN          
-MENU+R1+RIGHT    |Player 3 START
-MENU+L1+DOWN     |Player 4 COIN          
-MENU+R1+DOWN     |Player 4 START
+MENU+L2|Player 2 COIN
+MENU+R2|Player 2 SELECT
+SELECT+UP     |Player 2 COIN           
+START+UP       |Player 2 START
+SELECT+RIGHT     |Player 3 COIN          
+START+RIGHT    |Player 3 START
+SELECT+DOWN     |Player 4 COIN          
+START+DOWN     |Player 4 START
 
 ## SAVE/LOAD STATE
 
-You can save or load game states by pressing the MENU button when you are gaming, and select save or load state option. Also you can press button MENU+A (Load) or MENU+Y (Save) on a external controller. Then you should press button B (slot1) or button X (slot 2) to save or load the state. If you select Load or Save state from the MAME4iOS menu slot 1 is always used.
+You can save or load game states by pressing the MENU button when you are gaming, and select save or load state option. Also you can press button MENU+UP (Load) or MENU+DOWN (Save) on a external controller. 
 
 ## 8BitDo Zero 
 MAME4iOS supports the [8BitDo Zero](https://www.8bitdo.com/zero2/) when in KEYBOARD mode.
 
 ## Siri Remote
-MAME4iOS is now usable on a AppleTV using only the stock Siri Remote. You can only play games that use only the A and X buttons.
+MAME4iOS is now usable on a AppleTV using only the stock Siri Remote. You can only play games that use only the A and B buttons.
 
-to start playing a game, hit MENU and select "Coin + Start" from the list.
+to start playing a game, hit `MENU` and select `1 Player Start` from the list.
 
 | | |  
 -|-
 TRACKPAD MOVE   | emulate a dpad or joystick
 TRAKPAD CLICK   | A button
-PLAY            | X button
+PLAY            | B button
 MENU          | bring up the MAME4iOS menu
 
 ## iCADE (or compatible)
@@ -390,17 +396,15 @@ You can set the amount of overscan corrections in options menu.
 
 If you like iOS TVOUT mirror or you use and external 3rd party TVOUT app, you can turn off MAME4iOS native TVOUT in options menu.
 
-## INSTALLATION
+## MANUAL ROM INSTALLATION
 
-After installing, place your MAME-titled zipped roms in /var/mobile/Media/ROMs/MAME4iOS/roms folder for MAME4iOS for jailbroken devices
-
-On MAME4iOS for NO jailbroken devices, use iTunes file sharing (if your MAME4iOS build has it available) or use a 3rd party app like iFunBox or iExplorer to copy ROMs on sandboxed MAME4iOS 'Documents' folder:
+use iTunes file sharing (if your MAME4iOS build has it available) or use a 3rd party app like iFunBox or iExplorer to copy ROMs on sandboxed MAME4iOS 'Documents' folder:
 
 Step 1\. Downloaded iFunBox (or a similar utility) and plug your iOS device into your computer.
 
 Step 2\. Launch iFunBox and select your iOS device on the left hand side.
 
-Step 3\. If you don't have a jailbroken device, click on apps icon. Now you should see a list of all of your device’s applications. Locate MAME4iOS, click it, and select Documents. If you have a jailbroken device, click on raw file system icon and locate /var/mobile/Media/ROMs/MAME4iOS/roms folder.
+Step 3\. If you don't have a jailbroken device, click on apps icon. Now you should see a list of all of your device’s applications. Locate MAME4iOS, click it, and select Documents.
 
 Step 4\. And that’s all there is to it. Move your ROMs into this folder, launch MAME4iOS, and start playing!
 
@@ -462,7 +466,7 @@ Port to iOS by David Valdeita (Seleuco)
 
 ## KNOWN PROBLEMS
 
--Button mapping problems: Remove cfg files or folder besides rom folder.
+-Button mapping problems: Remove cfg files or folder besides rom folder, or do a `Settings` > `Reset`.
 
 ## INTERESTING WEBPAGES ABOUT MAME
 

--- a/iOS/EmulatorController.h
+++ b/iOS/EmulatorController.h
@@ -71,7 +71,6 @@ enum {BTN_A,BTN_B,BTN_Y,BTN_X,BTN_L1,BTN_R1,
 #if TARGET_OS_IOS
 @class AnalogStickView;
 @class LayoutView;
-@class NetplayGameKit;
 @class InfoHUD;
 #endif
 
@@ -86,14 +85,13 @@ enum {BTN_A,BTN_B,BTN_Y,BTN_X,BTN_L1,BTN_R1,
   @public UIView<ScreenView>* screenView;
   UIImageView	    * imageBack;
   UIImageView	    * imageOverlay;
-  UIImageView        * imageExternalDisplay;
-  UIImageView        * imageLogo;
-  UILabel            * fpsView;
+  UIImageView       * imageExternalDisplay;
+  UIImageView       * imageLogo;
+  UILabel           * fpsView;
 #if TARGET_OS_IOS
   AnalogStickView   * analogStickView;
-    LayoutView        *layoutView;    
-    NetplayGameKit     *netplayHelper;
-    InfoHUD         * hudView;
+  LayoutView        * layoutView;
+  InfoHUD           * hudView;
 #endif
   @public UIView	* externalView;
   UIView            * inputView;    // parent view of all the input views

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -4392,6 +4392,10 @@ CGRect scale_rect(CGRect rect, CGFloat scale) {
     }
     
     GCExtendedGamepad* gamepad = controller.extendedGamepad;
+    
+    // dont do multiple combo actions
+    if (g_menu_modifier_button_pressed[player])
+        return;
 
      // Add Coin / Select
      if (gamepad.leftShoulder.pressed) {
@@ -4430,6 +4434,7 @@ CGRect scale_rect(CGRect rect, CGFloat scale) {
          myosd_joy_status[player] &= ~MYOSD_X;
          [self runExit];
      }
+    
      // Load State
      else if (gamepad.buttonA.pressed ) {
          NSLog(@"%d: MENU+A => LOAD STATE", player);

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -2055,8 +2055,9 @@ static NSArray* list_trim(NSArray* _list) {
         g_mame_warning = 1;
     }
 
-    areControlsHidden = NO;
+    [self indexGameControllers];
     
+    areControlsHidden = NO;
     memset(cyclesAfterButtonPressed, 0, sizeof(cyclesAfterButtonPressed));
 }}
 
@@ -2310,7 +2311,6 @@ static BOOL controller_is_zero(int player) {
 // handle any input from *all* game controllers
 static void handle_device_input()
 {
-    // TODO: verify race condition with main thread
     NSArray* controllers = g_controllers;
 
     if (controllers.count == 0)
@@ -4261,6 +4261,20 @@ static unsigned long g_menuButtonPressed[NUM_JOY];  // bit set if a modifier but
         [self changeUI];
     }
 }
+
+// set the player index of all the game controllers, this needs to happen each time a new ROM is loaded.
+// MFi controllers have LED lights on them that shows the player number, so keep those current...
+-(void)indexGameControllers {
+    for (NSInteger index = 0; index < g_controllers.count; index++) {
+        GCController* controller = g_controllers[index];
+        // the Siri Remote, or any controller higher than MAME is looking for get mapped to Player 1
+        if (controller.extendedGamepad == nil || index >= myosd_num_inputs)
+            [controller setPlayerIndex:0];
+        else
+            [controller setPlayerIndex:index];
+    }
+}
+
 
 -(void)setupGameController:(GCController*)controller index:(NSInteger)index {
     NSLog(@"setupGameController[%ld]: %@", index, controller.vendorName);

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -4246,6 +4246,12 @@ static unsigned long g_menuButtonPressed[NUM_JOY];  // bit set if a modifier but
             [controllers addObject:controler];
     }
 
+    // cancel menu mode on all controllers, this is needed when a controller disconects in menu mode.
+    for (int i=0; i<g_controllers.count; i++) {
+        g_menuButton[i] = 0;
+        [self hideControllerHUD:g_controllers[i]];
+    }
+    
     for (NSInteger index = 0; index < controllers.count; index++) {
         GCController *controller = [controllers objectAtIndex:index];
         [self setupGameController:controller index:index];

--- a/iOS/HelpController.m
+++ b/iOS/HelpController.m
@@ -129,11 +129,12 @@ static NSString* html_viewport =
 
 static NSString* html_custom_style =
 @"<style>\n\
-code {background-color:lightgray; width:100%; overflow-x:scroll}\n\
+body {font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji; line-height:1.5}\n\
+code {background-color:lightgray; width:100%; overflow-x:scroll; padding:.2em .4em; margin:0; border-radius:6px; font-size:85%; font-family:SFMono-Regular,monospace}\n\
 @media (prefers-color-scheme: dark) {\n\
-    html {background-color: black; color: white;}\n\
-    table tbody tr:nth-child(2n) {background-color: #333333;}\n\
-    table tbody tr:nth-child(2n-1) {background-color: #222222;}\n\
+    html {background-color: #1e1e1e; color: white;}\n\
+    table tbody tr:nth-child(2n) {background-color: #323232;}\n\
+    table tbody tr:nth-child(2n-1) {background-color: #1e1e1e;}\n\
     a:link, a:visited {color: dodgerblue;}\n\
     img {opacity: .75;}\n\
     code {background-color:#404040;}\n\

--- a/iOS/MetalScreenView.m
+++ b/iOS/MetalScreenView.m
@@ -305,9 +305,6 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
     // see if the line shader wants past lines, ie does it list `line-time` in the parameter list.x
     _line_shader_wants_past_lines = [_line_shader rangeOfString:@"line-time"].length != 0;
     
-    if (_line_shader_wants_past_lines)
-        [self setShaderVariables:@{@"line-time": @(0.0)}];
-
     // parse the first param of the line shader to get the line width scale factor.
     // NOTE the first param can be a variable or a constant, support variables for the HUD.
     _line_width_scale = 1.0;

--- a/src/emu/cpu/mips/mips3drc.c
+++ b/src/emu/cpu/mips/mips3drc.c
@@ -543,12 +543,15 @@ static CPU_EXECUTE( mips3 )
 static CPU_EXIT( mips3 )
 {
 	mips3_state *mips3 = get_safe_token(device);
-	mips3com_exit(mips3);
+    if (mips3 != NULL)
+    {
+        mips3com_exit(mips3);
 
-	/* clean up the DRC */
-	drcfe_exit(mips3->impstate->drcfe);
-	drcuml_free(mips3->impstate->drcuml);
-	drccache_free(mips3->impstate->cache);
+        /* clean up the DRC */
+        drcfe_exit(mips3->impstate->drcfe);
+        drcuml_free(mips3->impstate->drcuml);
+        drccache_free(mips3->impstate->cache);
+    }
 }
 
 

--- a/src/osd/droid-ios/myosd.h
+++ b/src/osd/droid-ios/myosd.h
@@ -29,7 +29,7 @@ enum  { MYOSD_UP=0x1,       MYOSD_LEFT=0x4,       MYOSD_DOWN=0x10,   MYOSD_RIGHT
         MYOSD_START=1<<8,   MYOSD_SELECT=1<<9,    MYOSD_L1=1<<10,    MYOSD_R1=1<<11,
         MYOSD_A=1<<12,      MYOSD_B=1<<13,        MYOSD_X=1<<14,     MYOSD_Y=1<<15,
         MYOSD_L3=1<<16,     MYOSD_R3=1<<17,       MYOSD_L2=1<<18,    MYOSD_R2=1<<19,
-        MYOSD_EXIT=1<<20,   MYOSD_OPTION=1<<21,
+        MYOSD_EXIT=1<<20,   MYOSD_OPTION=1<<21,   MYOSD_HOME=1<<22,  MYOSD_MENU=1<<23,
 };
     
 #define MAX_FILTER_KEYWORD 30

--- a/src/osd/droid-ios/osdinput.c
+++ b/src/osd/droid-ios/osdinput.c
@@ -75,7 +75,7 @@ float joystick_read_analog(int n, char axis);
 static INT32 my_get_state(void *device_internal, void *item_internal);
 static INT32 my_axis_get_state(void *device_internal, void *item_internal);
 
-extern "C" void myosd_handle_turbo(void);
+extern "C" void myosd_poll_input(void);
 
 void droid_ios_init_input(running_machine *machine)
 {
@@ -348,7 +348,7 @@ float joystick_read_analog(int n, char axis)
 void droid_ios_poll_input(running_machine *machine)
 {    
     my_poll_ports(machine);
-	myosd_handle_turbo();
+    myosd_poll_input();
     
     long _pad_status = joystick_read(0);
     

--- a/xcode/MAME4iOS/Alert.h
+++ b/xcode/MAME4iOS/Alert.h
@@ -24,7 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 -(void)dismissWithAction:(UIAlertAction*)action completion: (void (^ __nullable)(void))completion;
 -(void)dismissWithDefault;
 -(void)dismissWithCancel;
--(void)dismissWithTitle:(NSString*)title;
 -(void)moveDefaultAction:(NSUInteger)direction;
 @end
 

--- a/xcode/MAME4iOS/Alert.m
+++ b/xcode/MAME4iOS/Alert.m
@@ -150,10 +150,6 @@
 {
     return [self dismissWithAction:self.cancelAction completion:nil];
 }
--(void)dismissWithTitle:(NSString*)title
-{
-    [self dismissWithAction:[self.actions filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"title BEGINSWITH[c] %@", title]].firstObject completion:nil];
-}
 -(void)moveDefaultAction:(NSUInteger)direction
 {
     NSInteger index = [self.actions indexOfObjectIdenticalTo:self.preferredAction];

--- a/xcode/MAME4iOS/InfoHUD.h
+++ b/xcode/MAME4iOS/InfoHUD.h
@@ -32,11 +32,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addTitle:(NSString*)str;
 - (void)addText:(NSString*)str;
 - (void)addView:(UIView*)view;
+- (void)addImage:(UIImage*)image;
 - (void)addSeparator;
 
 // toolbar and button items can be a UIImage or a NSString
 // strings starting with ":symbol-name:fallback:" will be expanded to a SF Symbol (or use fallback text)
 - (void)addToolbar:(NSArray*)items handler:(void (^)(NSUInteger button))handler;
+- (void)addButtons:(NSArray*)items color:(nullable UIColor*)color handler:(void (^)(NSUInteger button))handler;
 - (void)addButtons:(NSArray*)items handler:(void (^)(NSUInteger button))handler;
 - (void)addButton:(id)item color:(nullable UIColor*)color handler:(void (^)(void))handler;
 - (void)addButton:(id)item handler:(void (^)(void))handler;

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		EF301CF1240460C5000510FD /* Alert.m in Sources */ = {isa = PBXBuildFile; fileRef = EF301CF0240460C5000510FD /* Alert.m */; };
 		EF301CF2240460C5000510FD /* Alert.m in Sources */ = {isa = PBXBuildFile; fileRef = EF301CF0240460C5000510FD /* Alert.m */; };
 		EF301CF3240460F3000510FD /* ZipFile.m in Sources */ = {isa = PBXBuildFile; fileRef = EF27F36323F73CD400B1E50A /* ZipFile.m */; };
+		EF568DB025D5D4F600092B30 /* InfoHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = EFB3C6DB248C33DF00F44780 /* InfoHUD.m */; };
 		EF67E11624B8972100AFF489 /* MacMenu.m in Sources */ = {isa = PBXBuildFile; fileRef = EF67E11524B8972100AFF489 /* MacMenu.m */; };
 		EF7B232C23FD0469001FF51D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		EF7B232D23FD0469001FF51D /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -1448,6 +1449,7 @@
 				92A533C721EBDBAD0089FBB9 /* GCDWebServerDataRequest.m in Sources */,
 				926C76FF21F1C87700103EDE /* TVOptionsController.m in Sources */,
 				EF286D35253CA930007DA6D3 /* CloudSync.m in Sources */,
+				EF568DB025D5D4F600092B30 /* InfoHUD.m in Sources */,
 				EFF9F80A246356B300DDA88C /* CGScreenView.m in Sources */,
 				EF8E427E249348220049C84C /* megaTron.metal in Sources */,
 				92A5332621EBC8D00089FBB9 /* Bootstrapper.m in Sources */,


### PR DESCRIPTION
Cleanup the GameController code a little bit
* re-factor the `GameControllerSetup` code so it is not a single big hairy single function.
    - it is now multiple big hairy functions 😃 
* directly poll game controllers from the MAME thread, this way a button press should have less latency.
* more consistent button mapping between tvOS and iOS
* better support for MFi controllers (latest tvOS broke them....)
* New MENU combo buttons
* make the Siri Remote buttons be 🅐 and 🅑 (not 🅐 and 🅧) MAME considers 🅑 `BUTTON_2`
* MENU combo button "quick help"
* in-game MENU controller shortcuts, only on tvOS
* re-index game controllers on start of new game, so LED lights on MFi controllers will show correct player number. 
* see issue #285 and #279

## more consistent button mapping between tvOS and iOS

now using a Xbox/DualShock controller on iOS and tvOS will feel very similar, the left button will be SELECT and the right will be START. and on iOS the GUIDE button will be menu (not avail on tvOS)

SELECT + START will bring up the MAME4iOS menu.

## better support for MFi controllers (latest tvOS broke them....)

the latest tvOS has taken full control of the MENU and GUIDE button, what that means is MFi controllers must use the X+MENU method of menu-combos, and the Xbox GUIDE button will not bring up the MAME4iOS menu (it will bring up the system ControlCenter panel)

## New MENU combo buttons

change the MENU modifier buttons for Save/Load state so you don't have to bring up the M4i in-game menu causing a PAUSE and game play disruption.

| | |  
-|-
MENU           |Open MAME4iOS MENU   
MENU+L1     |Player 1 Coin                 
MENU+R1     |Player 1 Start               
MENU+L2     |Player 2 Coin                
MENU+R2     |Player 2 Start               
MENU+X       |Exit Game                 
MENU+Y       |Open MAME menu   
MENU+DOWN  |Save State ①               
MENU+UP        |Load State ①                
MENU+LEFT     |Save State ②                
MENU+RIGHT  |Load State ②      

## MENU combo button, quick help
If you hold down `MENU` (or `SELECT` or `START`) for a fixed amount (1sec) a "help screen" will popup on the screen (iOS and tvOS) showing the user what combo buttons are available. This is very similar to what [happens on an iPad if you hold down ⌘](https://support.apple.com/en-us/HT211096).  Unlike the in-game menu, this quick help does not pause the game and goes away instantly when `MENU` is released.

![IMG_C71D7E522832-1](https://user-images.githubusercontent.com/4494698/108008624-a00e7d80-6fb5-11eb-840b-b2a9038f5164.jpeg)

## in-game MENU controller shortcuts, only on tvOS

because on tvOS MFi controllers have such a bad MENU button experience and can't see the combo button quick help by just holding down the MENU button, we also show a subset of the combo buttons when the in-game menu is up.  the in-game menu uses the dpad and A,B so we can't show those, but we show all the others.

![Simulator Screen Shot - Apple TV 4K - 2021-02-15 at 17 42 37](https://user-images.githubusercontent.com/4494698/108008851-2925b480-6fb6-11eb-8cea-91b1e4215d18.png)







