### PR TITLE
Draw rotated or flipped textured QUADs correctly

### DIFF
--- a/iOS/MetalScreenView.m
+++ b/iOS/MetalScreenView.m
@@ -805,7 +805,7 @@ VertexColor VertexColorP3(CGFloat r, CGFloat g, CGFloat b, CGFloat a) {
 //      [X] flip X                      othunder
 //      [X] flip Y                      lethalen
 //      [X] swap XY                     kick
-//      [ ] swap XY + flip X + flip Y   ???
+//      [ ] swap XY + flip X + flip Y   
 //      [X] texture WRAP                MAME menu
 //      [X] texture CLAMP               MAME menu
 //

--- a/iOS/MetalScreenView.m
+++ b/iOS/MetalScreenView.m
@@ -592,16 +592,13 @@ static void load_texture_prim(id<MTLTexture> texture, myosd_render_primitive* pr
             else
                 [self setTextureAddressMode:MTLSamplerAddressModeClampToZero];
 
-            // draw a quad in the correct orientation
-            UIImageOrientation orientation = UIImageOrientationUp;
-            if (prim->texorient == ORIENTATION_ROT90)
-                orientation = UIImageOrientationRight;
-            else if (prim->texorient == ORIENTATION_ROT180)
-                orientation = UIImageOrientationDown;
-            else if (prim->texorient == ORIENTATION_ROT270)
-                orientation = UIImageOrientationLeft;
-
-            [self drawRect:rect color:color orientation:orientation];
+            // draw a textured rect.
+            [self drawPrim:MTLPrimitiveTypeTriangleStrip vertices:(Vertex2D[]){
+                Vertex2D(rect.origin.x,                  rect.origin.y,                   prim->texcoords[0].u,prim->texcoords[0].v,color),
+                Vertex2D(rect.origin.x + rect.size.width,rect.origin.y,                   prim->texcoords[1].u,prim->texcoords[1].v,color),
+                Vertex2D(rect.origin.x,                  rect.origin.y + rect.size.height,prim->texcoords[2].u,prim->texcoords[2].v,color),
+                Vertex2D(rect.origin.x + rect.size.width,rect.origin.y + rect.size.height,prim->texcoords[3].u,prim->texcoords[3].v,color),
+            } count:4];
         }
         else if (prim->type == RENDER_PRIMITIVE_QUAD) {
             // solid color quad. only ALPHA or NONE blend mode.
@@ -805,6 +802,10 @@ VertexColor VertexColorP3(CGFloat r, CGFloat g, CGFloat b, CGFloat a) {
 //      [X] rotate 90                   pacman
 //      [X] rotate 180                  mario, cocktail
 //      [X] rotate 270                  mario, cocktail.
+//      [X] flip X                      othunder
+//      [X] flip Y                      lethalen
+//      [X] swap XY                     kick
+//      [ ] swap XY + flip X + flip Y   ???
 //      [X] texture WRAP                MAME menu
 //      [X] texture CLAMP               MAME menu
 //
@@ -884,6 +885,15 @@ VertexColor VertexColorP3(CGFloat r, CGFloat g, CGFloat b, CGFloat a) {
             if (orient == ORIENTATION_ROT270)
                 assert(TRUE);
             
+            if (orient == ORIENTATION_FLIP_X)
+                assert(TRUE);
+            if (orient == ORIENTATION_FLIP_Y)
+                assert(TRUE);
+            if (orient == ORIENTATION_SWAP_XY)
+                assert(TRUE);
+            if (orient == (ORIENTATION_SWAP_XY | ORIENTATION_FLIP_X | ORIENTATION_FLIP_Y))
+                assert(FALSE);
+
             if (wrap == 0)
                 assert(TRUE);
             if (wrap == 1)

--- a/src/osd/droid-ios/myosd.h
+++ b/src/osd/droid-ios/myosd.h
@@ -223,6 +223,7 @@ struct _myosd_render_primitive
     uint32_t              texture_height;      /* height of the image */
     const void*           texture_palette;     /* palette for PALETTE16 textures, LUTs for RGB15/RGB32 */
     uint32_t              texture_seqid;       /* sequence ID */
+    uint32_t              texture_junk;        /* padding */
 //  render_quad_texuv     texcoords;           /* texture coordinates (for quad primitives) */
     struct {float u,v;}   texcoords[4];
 };
@@ -232,6 +233,7 @@ _Static_assert(sizeof(myosd_render_primitive) == sizeof(render_primitive), "");
 _Static_assert(offsetof(myosd_render_primitive, bounds_x0)    == offsetof(render_primitive, bounds), "");
 _Static_assert(offsetof(myosd_render_primitive, color_a)      == offsetof(render_primitive, color), "");
 _Static_assert(offsetof(myosd_render_primitive, texture_base) == offsetof(render_primitive, texture), "");
+_Static_assert(offsetof(myosd_render_primitive, texcoords)    == offsetof(render_primitive, texcoords), "");
 _Static_assert(PRIMFLAG_TEXORIENT_MASK == 0x000F);
 _Static_assert(PRIMFLAG_TEXFORMAT_MASK == 0x00F0);
 _Static_assert(PRIMFLAG_BLENDMODE_MASK == 0x0F00);


### PR DESCRIPTION
Use the texture UVs computed by MAME, don't try to make our own.