### PR TITLE
change how OSD passes the game_list to app.

### DIFF
--- a/src/emu/uimenu.c
+++ b/src/emu/uimenu.c
@@ -3885,16 +3885,8 @@ static void menu_select_game_build_driver_list(ui_menu *menu, select_game_state 
 			found_driver = (const game_driver **)bsearch(&tempdriver_ptr, menustate->driverlist, driver_count, sizeof(*menustate->driverlist), menu_select_game_driver_compare);
             
             int skip = found_driver == NULL;
- 
-//DAV HACK
-            if(!skip && myosd_filter_clones)
-            {
-                const game_driver *cloneof = driver_get_clone(*found_driver);
-                skip = cloneof!=NULL && !(cloneof->flags & GAME_IS_BIOS_ROOT);
-            }
-            if(!skip) skip = myosd_filter_not_working && (*found_driver)->flags & GAME_NOT_WORKING;
-//DAV HACK
-			/* if found, mark the corresponding entry in the array */
+
+            /* if found, mark the corresponding entry in the array */
 			if (!skip)
 			{                
                 int index = found_driver - menustate->driverlist;

--- a/src/osd/droid-ios/libmame.h
+++ b/src/osd/droid-ios/libmame.h
@@ -94,13 +94,36 @@ enum myosd_output_channel
 // subset of a internal game_driver structure we pass up to the UI/OSD layer
 typedef struct
 {
+    unsigned int        type;                       /* game type */
+    unsigned int        flags;                      /* MYOSD_GAME_INFO_ flags */
     const char *        source_file;                /* set this to __FILE__ */
     const char *        parent;                     /* if this is a clone, the name of the parent */
-    const char *        name;                       /* short (8-character) name of the game */
+    const char *        name;                       /* short (16-character) name of the game */
     const char *        description;                /* full name of the game */
     const char *        year;                       /* year the game was released */
     const char *        manufacturer;               /* manufacturer of the game */
+    const void *        rom_list;                   /* list of ROMs */
+    const void *        input_list;                 /* machine input */
+    const char *        software_list;              /* list of software */
 } myosd_game_info;
+
+enum MYOSD_GAME_TYPE
+{
+    MYOSD_GAME_TYPE_ARCADE,       // coin-operated machine for public use
+    MYOSD_GAME_TYPE_CONSOLE,      // console system
+    MYOSD_GAME_TYPE_COMPUTER,     // any kind of computer including home computers, minis, calculators, ...
+    MYOSD_GAME_TYPE_OTHER,        // any other emulated system (e.g. clock, satellite receiver, ...)
+};
+
+enum MYOSD_GAME_INFO
+{
+    MYOSD_GAME_INFO_VERTICAL            = 1<<0,     // vertical video (aka TATE)
+    MYOSD_GAME_INFO_NOT_WORKING         = 1<<1,     // not working
+    MYOSD_GAME_INFO_IMPERFECT_GRAPHICS  = 1<<2,     // imperfect video
+    MYOSD_GAME_INFO_IMPERFECT_SOUND     = 1<<3,     // imperfect sound
+    MYOSD_GAME_INFO_BIOS                = 1<<4,     // this driver entry is a BIOS root
+    MYOSD_GAME_INFO_SUPPORTS_SAVE       = 1<<5,     // system supports save states
+};
 
 // this is copy/clone of the render_primitive in render.h passed up to UI/OSD layer in myosd_video_draw
 typedef struct _myosd_render_primitive myosd_render_primitive;
@@ -139,7 +162,7 @@ struct _myosd_render_primitive
     struct {float u,v;}   texcoords[4];
 };
 
-#ifndef __RENDER_H__
+#ifndef ORIENTATION_FLIP_X
 /* render primitive types */
 enum
 {
@@ -303,18 +326,12 @@ enum MYOSD_STATE {
     MYOSD_STATE_CONFIGURE_INPUT = 1<<2,     // configure input menu is active
 };
 
-enum MYOSD_FILTER {
-    MYOSD_FILTER_NOTWORKING = 1<<0,         // filter (dont show) non-working machines
-    MYOSD_FILTER_CLONES     = 1<<1,         // filter (dont show) clones
-};
-
 enum {
     MYOSD_VERSION,              // GET: MAME version number (ie 139 or 229)
     MYOSD_VERSION_STRING,       // GET: MAME version string (ie "0.139u1 (date)")
     MYOSD_STATE,                // GET: APP STATE (inGame, inMenu, inInput)
     MYOSD_DISPLAY_WIDTH,        // SET: maximum width and height of "screen" to display
     MYOSD_DISPLAY_HEIGHT,
-    MYOSD_GAME_FILTER,          // SET: game driver filter (Available, Working, or Clones)
     MYOSD_FPS,                  // GET, SET: show framerate
     MYOSD_SPEED,                // GET, SET: emulation speed (100 = 100%)
     MYOSD_HISCORE,              // GET, SET: HISCORE system enabled
@@ -335,7 +352,8 @@ typedef struct {
 
     void (*input_poll)(myosd_input_state* input, size_t state_size);
     void (*output_text)(int channel, const char* text);
-    void (*set_game_info)(myosd_game_info *info[], int game_count);
+    
+    void (*set_game_info)(myosd_game_info *games, int count);
 }   myosd_callbacks;
 
 // main entry point

--- a/src/osd/droid-ios/myosd.h
+++ b/src/osd/droid-ios/myosd.h
@@ -26,8 +26,6 @@ extern int  myosd_display_height;       // ...set in the iOS app, to pick a good
 extern int  myosd_force_pxaspect;
 extern int  myosd_hiscore;
 extern int  myosd_speed;
-extern int  myosd_filter_clones;
-extern int  myosd_filter_not_working;
 
 extern void myosd_init(void);
 extern void myosd_deinit(void);
@@ -38,50 +36,6 @@ extern void myosd_set_game_info(const game_driver *info[], int game_count);
 extern void myosd_openSound(int rate,int stereo);
 extern void myosd_closeSound(void);
 extern void myosd_sound_play(void *buff, int len);
-
-#ifdef __MACHINE_H__
-_Static_assert(MYOSD_OUTPUT_ERROR == OUTPUT_CHANNEL_ERROR);
-_Static_assert(MYOSD_OUTPUT_WARNING == OUTPUT_CHANNEL_WARNING);
-_Static_assert(MYOSD_OUTPUT_INFO == OUTPUT_CHANNEL_INFO);
-_Static_assert(MYOSD_OUTPUT_DEBUG == OUTPUT_CHANNEL_DEBUG);
-_Static_assert(MYOSD_OUTPUT_VERBOSE == OUTPUT_CHANNEL_VERBOSE);
-#endif
-
-#ifdef __DRIVER_H__
-// fail to compile if these structures get out of sync.
-_Static_assert(offsetof(myosd_game_info, source_file)  == offsetof(game_driver, source_file), "");
-_Static_assert(offsetof(myosd_game_info, parent)       == offsetof(game_driver, parent), "");
-_Static_assert(offsetof(myosd_game_info, name)         == offsetof(game_driver, name), "");
-_Static_assert(offsetof(myosd_game_info, description)  == offsetof(game_driver, description), "");
-_Static_assert(offsetof(myosd_game_info, year)         == offsetof(game_driver, year), "");
-_Static_assert(offsetof(myosd_game_info, manufacturer) == offsetof(game_driver, manufacturer), "");
-#endif
-
-// NOTE if you get a re-defined enum error, you need to include emu.h before myosd.h
-#ifdef __RENDER_H__
-// myosd struct **must** match the internal render.h version.
-_Static_assert(sizeof(myosd_render_primitive) == sizeof(render_primitive), "");
-_Static_assert(offsetof(myosd_render_primitive, bounds_x0)    == offsetof(render_primitive, bounds), "");
-_Static_assert(offsetof(myosd_render_primitive, color_a)      == offsetof(render_primitive, color), "");
-_Static_assert(offsetof(myosd_render_primitive, texture_base) == offsetof(render_primitive, texture), "");
-_Static_assert(offsetof(myosd_render_primitive, texcoords)    == offsetof(render_primitive, texcoords), "");
-_Static_assert(PRIMFLAG_TEXORIENT_MASK == 0x000F);
-_Static_assert(PRIMFLAG_TEXFORMAT_MASK == 0x00F0);
-_Static_assert(PRIMFLAG_BLENDMODE_MASK == 0x0F00);
-_Static_assert(PRIMFLAG_ANTIALIAS_MASK == 0x1000);
-_Static_assert(PRIMFLAG_SCREENTEX_MASK == 0x2000);
-_Static_assert(PRIMFLAG_TEXWRAP_MASK   == 0x4000);
-#endif
-
-#ifdef __INPUT_H__
-// make sure MYOSD_KEY enum matches ITEM_ID enum
-_Static_assert(MYOSD_KEY_A == ITEM_ID_A);
-_Static_assert(MYOSD_KEY_0 == ITEM_ID_0);
-_Static_assert(MYOSD_KEY_F1 == ITEM_ID_F1);
-_Static_assert(MYOSD_KEY_ESC == ITEM_ID_ESC);
-_Static_assert(MYOSD_KEY_LCMD == ITEM_ID_LWIN);
-_Static_assert(MYOSD_KEY_CANCEL == ITEM_ID_CANCEL);
-#endif
 
 #if defined(__cplusplus)
 }

--- a/src/osd/droid-ios/osdinput.c
+++ b/src/osd/droid-ios/osdinput.c
@@ -87,6 +87,14 @@ void droid_ios_init_input(running_machine *machine)
 	if (keyboard_device == NULL)
 		fatalerror("Error creating keyboard device");
     
+    // make sure MYOSD_KEY enum matches ITEM_ID enum
+    _Static_assert(MYOSD_KEY_A == ITEM_ID_A);
+    _Static_assert(MYOSD_KEY_0 == ITEM_ID_0);
+    _Static_assert(MYOSD_KEY_F1 == ITEM_ID_F1);
+    _Static_assert(MYOSD_KEY_ESC == ITEM_ID_ESC);
+    _Static_assert(MYOSD_KEY_LCMD == ITEM_ID_LWIN);
+    _Static_assert(MYOSD_KEY_CANCEL == ITEM_ID_CANCEL);
+    
     // add a key for every MAME key
     for (input_item_id key=ITEM_ID_A; key<=ITEM_ID_CANCEL; key++) {
         astring token;


### PR DESCRIPTION
pass more info up to app in myosd_game_info
* game type (arcade, console, computer, other)
* game flags (IS_BIOS, VERTICAL, NOT_WORKING, IMPERFECT_GRAPHICS, ...)

this is a change to match current `MAME` 