### PR TITLE
Modern mame

### DIFF
--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -2501,9 +2501,13 @@ static void handle_device_input(myosd_input_state* myosd)
         for (int index = 0; index < controllers_count; index++) {
             GCController *controller = controllers[index];
             int player = (int)controller.playerIndex;
+            
+            // TODO: this prevents mapping buttons for player 2,3,4
+            // TODO: ...so until we handle native input mapping dont do this.
             // when in a MAME menu (or the root) let any controller work the UI
-            if (myosd->input_mode == MYOSD_INPUT_MODE_UI)
-                player = 0;
+            //if (myosd->input_mode == MYOSD_INPUT_MODE_UI)
+            //    player = 0;
+            
             // dont overwrite a lower index controller, unless....
             if (player == index || controller_is_zero(myosd, player))
                 read_player_controller(controller, myosd, index, player);

--- a/iOS/Globals.h
+++ b/iOS/Globals.h
@@ -71,12 +71,8 @@
 
 #define absf(x)			    ((x >= 0) ? (x) : (x * -1.0f))
 
-#define myosd_state myosd_get(MYOSD_STATE)
-#define myosd_inGame (myosd_state & MYOSD_STATE_INGAME)
-#define myosd_in_menu (myosd_state & MYOSD_STATE_INMENU)
-
-#define STICK4WAY (g_joy_ways == 4 || !myosd_inGame || myosd_in_menu)
-#define STICK2WAY (g_joy_ways == 2 && myosd_inGame && !myosd_in_menu)
+#define STICK4WAY (g_joy_ways == 4)
+#define STICK2WAY (g_joy_ways == 2)
 
 #define MyCGRectContainsPoint(rect, point)						\
 (((point.x >= rect.origin.x) &&								\

--- a/src/emu/ui.c
+++ b/src/emu/ui.c
@@ -180,7 +180,6 @@ static INT32 slider_crossoffset(running_machine *machine, void *arg, astring *st
 
 INLINE UINT32 ui_set_handler(UINT32 (*callback)(running_machine *, render_container *, UINT32), UINT32 param)
 {
-    myosd_in_menu = callback != handler_ingame;
 	ui_handler_callback = callback;
 	ui_handler_param = param;
 	return param;

--- a/src/emu/uimenu.c
+++ b/src/emu/uimenu.c
@@ -1919,7 +1919,6 @@ static void menu_input_common(running_machine *machine, ui_menu *menu, void *par
 		/* if UI_CANCEL is pressed, abort */
 		if (ui_input_pressed(machine, IPT_UI_CANCEL))
 		{
-            myosd_in_menu = 1;
 			menustate->pollingitem = NULL;
 			menustate->record_next = FALSE;
 			toggle_none_default(&item->seq, &menustate->starting_seq, item->defseq);
@@ -1931,7 +1930,6 @@ static void menu_input_common(running_machine *machine, ui_menu *menu, void *par
 		/* poll again; if finished, update the sequence */
 		if (input_seq_poll(machine, &newseq))
 		{
-            myosd_in_menu = 1;
 			menustate->pollingitem = NULL;
 			menustate->record_next = TRUE;
 
@@ -1953,7 +1951,6 @@ static void menu_input_common(running_machine *machine, ui_menu *menu, void *par
 		{
 			/* an item was selected: begin polling */
 			case IPT_UI_SELECT:
-                myosd_in_menu = 2;
 				menustate->pollingitem = item;
 				menustate->last_sortorder = item->sortorder;
 
@@ -3599,10 +3596,6 @@ static void menu_select_game(running_machine *machine, ui_menu *menu, void *para
 	select_game_state *menustate;
 	const ui_menu_event *event;
 
-//DAV HACK
-	myosd_in_menu =  0;
-//DAV HACK
-
 	/* if no state, allocate some */
 	if (state == NULL)
 	{
@@ -3656,9 +3649,6 @@ static void menu_select_game(running_machine *machine, ui_menu *menu, void *para
 			/* special case for configure inputs */
 			if ((FPTR)driver == 1)
 			{
-				//DAV HACK
-				myosd_in_menu =  1;
-				//DAV HACK
 				ui_menu_stack_push(ui_menu_alloc(menu->machine, menu->container, menu_input_groups, NULL));
 			}
 			/* anything else is a driver */

--- a/src/osd/droid-ios/libmame.h
+++ b/src/osd/droid-ios/libmame.h
@@ -78,8 +78,25 @@ typedef struct {
     int num_mouse;
     int num_lightgun;
     int num_keyboard;
+    
+    // current input mode
+    int input_mode;
+    int keyboard_mode;
 
 }   myosd_input_state;
+
+// myosd input mode
+enum myosd_input_mode
+{
+    MYOSD_INPUT_MODE_NORMAL,
+    MYOSD_INPUT_MODE_UI
+};
+
+// myosd keyboard mode
+enum myosd_keyboard_mode
+{
+    MYOSD_KEYBOARD_MODE_NORMAL
+};
 
 // myosd output
 enum myosd_output_channel
@@ -89,6 +106,7 @@ enum myosd_output_channel
     MYOSD_OUTPUT_INFO,
     MYOSD_OUTPUT_DEBUG,
     MYOSD_OUTPUT_VERBOSE,
+    MYOSD_OUTPUT_LOG,
 };
 
 // subset of a internal game_driver structure we pass up to the UI/OSD layer
@@ -162,7 +180,7 @@ struct _myosd_render_primitive
     struct {float u,v;}   texcoords[4];
 };
 
-#ifndef ORIENTATION_FLIP_X
+#if !defined(MAME_EMU_RENDER_H) && !defined(ORIENTATION_FLIP_X)
 /* render primitive types */
 enum
 {
@@ -320,16 +338,9 @@ enum myosd_keycode
 
 // myosd_get and myosd_set - get and set global state from the MAME driver.
 
-enum MYOSD_STATE {
-    MYOSD_STATE_INGAME  = 1<<0,             // running a machine/game
-    MYOSD_STATE_INMENU  = 1<<1,             // a mame configure menu is active
-    MYOSD_STATE_CONFIGURE_INPUT = 1<<2,     // configure input menu is active
-};
-
 enum {
     MYOSD_VERSION,              // GET: MAME version number (ie 139 or 229)
     MYOSD_VERSION_STRING,       // GET: MAME version string (ie "0.139u1 (date)")
-    MYOSD_STATE,                // GET: APP STATE (inGame, inMenu, inInput)
     MYOSD_DISPLAY_WIDTH,        // SET: maximum width and height of "screen" to display
     MYOSD_DISPLAY_HEIGHT,
     MYOSD_FPS,                  // GET, SET: show framerate
@@ -341,19 +352,26 @@ extern intptr_t myosd_get(int var);
 extern void myosd_set(int var, intptr_t value);
 
 // MYOSD app callback functions
-// video_init, video_draw, and input_poll are required, others can be NULL
 typedef struct {
+    
+    void (*game_init)(myosd_game_info *info);
+    void (*game_exit)(void);
+    
     void (*video_init)(int width, int height);
     void (*video_draw)(myosd_render_primitive* prim_list, int width, int height);
+    void (*video_exit)(void);
 
     void (*sound_init)(int rate, int stereo);
     void (*sound_play)(void *buff, int len);
     void (*sound_exit)(void);
 
+    void (*input_init)(myosd_input_state* input, size_t state_size);
     void (*input_poll)(myosd_input_state* input, size_t state_size);
-    void (*output_text)(int channel, const char* text);
+    void (*input_exit)(void);
     
+    void (*output_text)(int channel, const char* text);
     void (*set_game_info)(myosd_game_info *games, int count);
+
 }   myosd_callbacks;
 
 // main entry point

--- a/src/osd/droid-ios/myosd.h
+++ b/src/osd/droid-ios/myosd.h
@@ -18,8 +18,6 @@ extern "C" {
 #endif
 
 // globals in osd-ios.c
-extern int  myosd_inGame;
-extern int  myosd_in_menu;
 extern int  myosd_fps;
 extern int  myosd_display_width;        // display width,height is the screen output resolution
 extern int  myosd_display_height;       // ...set in the iOS app, to pick a good default render target size.
@@ -29,13 +27,17 @@ extern int  myosd_speed;
 
 extern void myosd_init(void);
 extern void myosd_deinit(void);
+extern void myosd_machine_init(running_machine *machine);
+extern void myosd_machine_exit(running_machine *machine);
 extern void myosd_set_video_mode(int width,int height);
 extern void myosd_video_draw(render_primitive*, int width, int height);
+extern void myosd_poll_input_init(myosd_input_state* input);
 extern void myosd_poll_input(myosd_input_state* input);
 extern void myosd_set_game_info(const game_driver *info[], int game_count);
 extern void myosd_openSound(int rate,int stereo);
 extern void myosd_closeSound(void);
 extern void myosd_sound_play(void *buff, int len);
+
 
 #if defined(__cplusplus)
 }

--- a/src/osd/droid-ios/osdinput.c
+++ b/src/osd/droid-ios/osdinput.c
@@ -11,6 +11,7 @@
 
 #include "osdepend.h"
 #include "emu.h"
+#include "ui.h"
 #include "uimenu.h"
 
 #include "myosd.h"
@@ -254,6 +255,8 @@ void my_poll_ports(running_machine *machine)
         mame_printf_debug("Num MOUSE %d\n",myosd_input.num_mouse);
         mame_printf_debug("Num GUN %d\n",myosd_input.num_lightgun);
         mame_printf_debug("Num KEYBOARD %d\n",myosd_input.num_keyboard);
+        
+        myosd_poll_input_init(&myosd_input);
     }
     
 }
@@ -270,6 +273,9 @@ static float myosd_joystick_read_analog(int n, int axis)
 
 void droid_ios_poll_input(running_machine *machine)
 {    
+    myosd_input.input_mode = ui_is_menu_active() ? MYOSD_INPUT_MODE_UI : MYOSD_INPUT_MODE_NORMAL;
+    myosd_input.keyboard_mode = MYOSD_KEYBOARD_MODE_NORMAL;
+
     my_poll_ports(machine);
     myosd_poll_input(&myosd_input);
     

--- a/src/osd/droid-ios/osdmain.c
+++ b/src/osd/droid-ios/osdmain.c
@@ -68,8 +68,6 @@ int main(int argc, char **argv)
 {
 	myosd_init();
 
-    droid_ios_setup_video();
-
     int ret = cli_execute(argc, argv, droid_mame_options);
     
 	myosd_deinit();
@@ -83,16 +81,13 @@ int main(int argc, char **argv)
 
 void osd_init(running_machine *machine)
 {
-
-	//add_exit_callback(machine, osd_exit);
 	machine->add_notifier(MACHINE_NOTIFY_EXIT, osd_exit);
 
 	our_target = render_target_alloc(machine, NULL, 0);
 	if (our_target == NULL)
 		fatalerror("Error creating render target");
 
-	myosd_inGame = !(machine->gamedrv == &GAME_NAME(empty));
-    
+    myosd_machine_init(machine);
 	droid_ios_init_input(machine);
 	droid_ios_init_sound(machine);
 	droid_ios_init_video(machine);
@@ -104,6 +99,7 @@ static void osd_exit(running_machine &machine)
 	if (our_target != NULL)
 		render_target_free(our_target);
 	our_target = NULL;
+    myosd_machine_exit(&machine);
 }
 
 void osd_update(running_machine *machine, int skip_redraw)

--- a/src/osd/droid-ios/osdvideo.c
+++ b/src/osd/droid-ios/osdvideo.c
@@ -26,14 +26,6 @@ static int curr_screen_height;
 static int curr_vis_area_screen_width;
 static int curr_vis_area_screen_height;
 
-void droid_ios_setup_video()
-{
-}
-
-static void droid_ios_video_cleanup(running_machine &machine)
-{
-}
-
 void droid_ios_init_video(running_machine *machine)
 {
 	curr_screen_width = 1;
@@ -45,8 +37,6 @@ void droid_ios_init_video(running_machine *machine)
 	screen_height = 1;
 	vis_area_screen_width = 1;
 	vis_area_screen_height = 1;
-
-	machine->add_notifier(MACHINE_NOTIFY_EXIT, droid_ios_video_cleanup);
 }
 
 void droid_ios_video_draw(const render_primitive_list *currlist)


### PR DESCRIPTION
## more OSD cleanup
* remove OSD globals `myosd_inGame` and `myosd_in_menu`
* added `video_exit`, `input_init`, `input_exit` host callbacks.
* added `game_init`, and `game_exit` callbacks for current machine.
* added `input_mode` and `keyboard_mode` to `myosd_input_state`