### PR TITLE
Modern MAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,19 +96,19 @@ Even if you are not in the paid Apple Developer Program, you can sideload the ap
         2. Select the project name on the left pane and make sure your personal team is selected
         3. Hit the `▶︎` Run button to install on your device. _Done._
         
-## How to build with latest `MAME`
+## How to build `MAME4iOS` with the latest version of `MAME`
 
-* if you want to build MAME
+* if you want to build `MAME`
     - clone this fork of [MAME](https://github.com/ToddLa/mame)
     - switch to the `ios-osd` branch.
     - run `./make-ios.sh` (or `./make-ios.sh tvos`) in the forked `MAME`
-    - go watch [this](https://www.imdb.com/title/tt0056172/) or maybe [this](https://en.wikipedia.org/wiki/The_Godfather_(film_series)) while you wait for `MAME` to build.
+    - go watch [this](https://www.imdb.com/title/tt3748528/) then [this](https://en.wikipedia.org/wiki/Star_Wars_Trilogy) while you wait for `MAME` to build.
     - now switch directories to your `MAME4iOS` project
-    - instead of running  `./make-ios.sh` run  `./get-libmame.sh <path to your MAME clone>`
+    - instead of running  `./make-ios.sh` run  `./get-libmame.sh ios <path to your MAME clone>`
     - build and run in Xcode.
     
 * if you want to use the latest pre-build `libmame`
-    - instead of running  `./make-ios.sh` run  `./get-libmame.sh`
+    - instead of running  `./make-ios.sh` run  `./get-libmame.sh` or  `./get-libmame.sh tvos`
     - build and run in Xcode.
 
 ## Issues running current `MAME`

--- a/README.md
+++ b/README.md
@@ -97,21 +97,24 @@ Even if you are not in the paid Apple Developer Program, you can sideload the ap
         3. Hit the `▶︎` Run button to install on your device. _Done._
         
 ## How to build with latest `MAME`
-* clone this fork of [MAME](https://github.com/ToddLa/mame)
-* switch to the `ios-osd` branch.
-* run `./make-ios.sh` (or `./make-ios.sh tvos`) in the forked `MAME`
-* go watch [this](https://www.imdb.com/title/tt0056172/) or maybe [this](https://en.wikipedia.org/wiki/The_Godfather_(film_series)) while you wait for `MAME` to build.
-* now switch directories to your `MAME4iOS` project
-* instead of running  `./make-ios.sh` run  `./get-libmame.sh`
-    - if your projects are not *side by side* or you did not name the fork `MAME`, then pass the path to the `MAME` fork to the script.
-    - for example if you cloned into `~/MyCode/ToddMAME` then run `./get-libmame.sh ~/MyCode/ToddMAME`
-* now you can build and run in Xcode.
+
+* if you want to build MAME
+    - clone this fork of [MAME](https://github.com/ToddLa/mame)
+    - switch to the `ios-osd` branch.
+    - run `./make-ios.sh` (or `./make-ios.sh tvos`) in the forked `MAME`
+    - go watch [this](https://www.imdb.com/title/tt0056172/) or maybe [this](https://en.wikipedia.org/wiki/The_Godfather_(film_series)) while you wait for `MAME` to build.
+    - now switch directories to your `MAME4iOS` project
+    - instead of running  `./make-ios.sh` run  `./get-libmame.sh <path to your MAME clone>`
+    - build and run in Xcode.
+    
+* if you want to use the latest pre-build `libmame`
+    - instead of running  `./make-ios.sh` run  `./get-libmame.sh`
+    - build and run in Xcode.
 
 ## Issues running current `MAME`
 * most `MAME` 139 ROMs dont work on 229, but that is just normal life in `MAME` world, see [this](#mixing-139-and-2xx-roms).
 * tracking down a sound issue and other random stuff.
-* some things (like being smart about number of players, etc) does not work (yet)
-* if you run a `Computer` machine you will be stuck and cant exit cuz we dont handle ui_mode and keyboards right (yet)
+* if you run a `Computer` machine, you need a USB keyboard, and backslash is ui_mode_key.
 * the `hiscore` and `cheat` system has not been updated.
 
 ## **Software Lists**
@@ -123,8 +126,10 @@ they are not compiled in code but use as valuable source of information in order
 
 * first import a *software list xml* file, you can find these files [here](https://github.com/mamedev/mame/tree/master/hash)
     - you can also copy software list xml files *by hand* to the `hash` directory.
-* you might be tempted to just import *all* software list files, dont do that, it will waste diskspace on your device, and cause `MAME4iOS` to do extra work.
-* after you have imported the software list xml files, you can import `ZIP` files containing software.  The name of the `ZIP` file *or* the subdirectory path in the `ZIP` file needs to match the name of a software list.
+* you might be tempted to just import *all* software list files, **dont** do that, it will waste diskspace on your device, and cause `MAME4iOS` to do extra work.
+* after you have imported the software list xml files, you can import `ZIP` files containing software. 
+
+If the name of the `ZIP` file *or* the subdirectory path in the `ZIP` matches the name of a software list, it will be imported directly, otherwise all software lists will be searched for a match.
 
 example zip file(s)
 ```

--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ Even if you are not in the paid Apple Developer Program, you can sideload the ap
     - build and run in Xcode.
 
 ## Issues running current `MAME`
-* most `MAME` 139 ROMs dont work on 229, but that is just normal life in `MAME` world, see [this](#mixing-139-and-2xx-roms).
+* most `MAME` 139 ROMs dont work on 2xx, but that is just normal life in `MAME` world, see [this](#mixing-139-and-2xx-roms).
 * tracking down a sound issue and other random stuff.
-* if you run a `Computer` machine, you need a USB keyboard, and backslash is ui_mode_key.
+* if you run a `Computer` machine, you need a USB keyboard, and `\` (backslash) is the ui_mode_key.
 * the `hiscore` and `cheat` system has not been updated.
+* `MAME` Configure menu has a `Add To Favorites` and `Select New Machine` that dont interact with the `MAME4iOS` Ux.
 
 ## **Software Lists**
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Even if you are not in the paid Apple Developer Program, you can sideload the ap
 ## How to build `MAME4iOS` with the latest version of `MAME`
 
 * if you want to build `MAME`
-    - clone this fork of [MAME](https://github.com/ToddLa/mame)
+    - clone [this fork](https://github.com/ToddLa/mame) of `MAME`
     - switch to the `ios-osd` branch.
     - run `./make-ios.sh` (or `./make-ios.sh tvos`) in the forked `MAME`
     - go watch [this](https://www.imdb.com/title/tt3748528/) then [this](https://en.wikipedia.org/wiki/Star_Wars_Trilogy) while you wait for `MAME` to build.

--- a/TODO.md
+++ b/TODO.md
@@ -1,23 +1,30 @@
 # MAME 2xx TODO
 
 * Font is getting scaled badly, show info on startup is unreadable. 
+    - fixed we always run at hi-res now.
 * Font scaled textures not cached, getting re-loaded every frame when Config or Main Menu is active. A seqid problem similar to one I fixed in 139. 
 * Command line options for -cheat, -bench, -beam width need fixed. 
+    - fixed
 * Need to update at least help, and maybe UI to call out options that can’t be changed without restarting game. 
+    - fixed any Settings change causes a restart
 * How does the cheat system work on 2xx, do we need a new cheat.zip? Does the old one being around break anything?? Can we have a cheat.7z co-exist with cheat.zip
 * How does new hiscore system work, will old dat file conflict
-* MAME 2xx will run/restore the last game, this is **bad** and needs turned off in the OSD. M4i manages restoring last game. 
 * Figure out correct solution to delayed game_list
     - maybe dont pause the MAME thread when ChooseUI is active, just dont send any input to MAME.
+    - fixed, we dont hard pause MAME when the UI is up.
 * OSD needs to get the “input profile” for the current game (ie num-players, etc)
+    - done.
 * Clean up the OSD module stuff
+    - done module stuff is all gone.
 * Find out is FORCE_DRC_C_BACKEND or NOASM needed. 
     * -[no]drc
     * -drc_use_c
 * Test mouse and lightgun input. 
 * Handle sending command keys to MAME when in a game that uses the keyboard. 
-    *  Big problem for ESC, we can’t even exit (maybe have a special MYOSD exit command, or special key)
+    -  Big problem for ESC, we can’t even exit (maybe have a special MYOSD exit command, or special key)
+    - fixed we do a schedule-exit so MAME will exit, even in a keyboard machine.
 * Support switching keyboard modes, support UIMODEKEY 
+    - uimodekey is mapped to backslash in DEBUG (for now)
 * Support an on-screen keyboard for games that use keyboard, figure out simple UI for it.
     * Menu or HUD command to hide/show keyboard?
     * See if alpha can be applied to system keyboard?
@@ -31,6 +38,7 @@
     * -str <n> -video none -sound none -nothrottle
 * Support -autosave (139 and 2xx)
 * Show Snaps and Videos in the UI and let user delete them (or make a snap the title image)
+    - done.
 * Figure out right value to use for osd-numprocessors
 * Investigate pre-scale.
 * Watchdog timer?
@@ -39,5 +47,5 @@
 * -bios <name>
 * LUA console and HTTP server, disable?
 * Support LCD screen type.
-* 
+    - LCD is detected, but no special shader yet.
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 * Font is getting scaled badly, show info on startup is unreadable. 
     - fixed we always run at hi-res now.
+* investigate loooooong startup time, and what can we do about it.
 * Font scaled textures not cached, getting re-loaded every frame when Config or Main Menu is active. A seqid problem similar to one I fixed in 139. 
 * Command line options for -cheat, -bench, -beam width need fixed. 
     - fixed

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,17 +1,17 @@
 # Version 2021.7
 * `OSD` changes.
-* Ability to build with latest `MAME` version (229 or higher)
+* Ability to build with latest `MAME` version (0.232)
 * New `Category.ini` from `MAME` 230
 * Attack of the Clones! - support import of merged romsets.
 * `MAME` Software List (aka softlist) support.
     - allow sloftlist `XML` files to be imported.
     - *smart* import of software romsets.
-* Collapsable sections in ChooseGame UI
+* Collapsable sections in `ChooseGameUI`
 * Snapshot button on `HUD` and ability to use a Snapshot as Title image.
 * handle import of `7z` files.
-    - **note** *smart import* does not work fully with `7z` romsets, they are just assumed to be a arcade (not software) romset.
     - 139 version of `MAME4iOS` will ignore `7z` romsets
 * Support for new `Apple Remote` with tvOS 14.6
+* Added ability to group Clones in a different section in `ChooseGameUI`
 
 # Version 2021.6
 * `Mouse` device support.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -2,6 +2,15 @@
 * `OSD` changes.
 * New `Category.ini` from `MAME` 230
 * Ability to build with latest `MAME` version (229 or higher)
+* Attack of the Clones! - support import of merged romsets.
+* `MAME` Software List (aka softlist) support.
+    - allow sloftlist `XML` files to be imported.
+    - *smart* import of software romsets.
+* Collapsable sections in ChooseGame UI
+* Snapshot button on `HUD` and ability to use a Snapshot as Title image.
+* handle import of `7z` files.
+    - **note** *smart import* does not work fully with `7z` romsets, they are just assumed to be a arcade (not software) romset.
+    - 139 version of `MAME4iOS` will ignore `7z` romsets
 
 # Version 2021.6
 * `Mouse` device support.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,7 +1,7 @@
 # Version 2021.7
 * `OSD` changes.
-* New `Category.ini` from `MAME` 230
 * Ability to build with latest `MAME` version (229 or higher)
+* New `Category.ini` from `MAME` 230
 * Attack of the Clones! - support import of merged romsets.
 * `MAME` Software List (aka softlist) support.
     - allow sloftlist `XML` files to be imported.
@@ -11,6 +11,7 @@
 * handle import of `7z` files.
     - **note** *smart import* does not work fully with `7z` romsets, they are just assumed to be a arcade (not software) romset.
     - 139 version of `MAME4iOS` will ignore `7z` romsets
+* Support for new `Apple Remote` with tvOS 14.6
 
 # Version 2021.6
 * `Mouse` device support.

--- a/get-libmame.sh
+++ b/get-libmame.sh
@@ -15,7 +15,7 @@
 ##
 
 if [ "$1" == "" ]; then
-    $0 ios $2
+    $0 ios
     exit
 fi
 
@@ -40,5 +40,9 @@ if [ -f "../MAME/$LIBMAME" ]; then
     exit
 fi
 
-echo "USAGE: $0 [ios | tvos | mac | all] [source]"
+## download from GitHub if no local version
+echo DOWNLOAD $LIBMAME
+curl -L  curl -L "https://github.com/ToddLa/mame/releases/download/mame0231/$LIBMAME.gz" | gunzip > $LIBMAME
+
+## echo "USAGE: $0 [ios | tvos | mac | all] [source]"
 

--- a/get-libmame.sh
+++ b/get-libmame.sh
@@ -8,7 +8,7 @@
 ## target is one of the following
 ##      ios     get libmame-ios.a for iOS
 ##      tvos    get libmame-tvos.a for tvOS
-##      mac     get libmame.a for Catalyst
+##      mac     get libmame-mac.a for Catalyst
 ##      all     get all
 ##
 ## source is path to MAME project or blank for default (../MAME)
@@ -26,9 +26,15 @@ if [ "$1" == "all" ]; then
     exit
 fi
 
-LIBMAME="libmame-$1.a"
+if [ "$1" != "ios" ] && [ "$1" != "tvos" ] && [ "$1" != "mac" ]; then
+    echo "USAGE: $0 [ios | tvos | mac | all] [path to MAME]"
+    exit
+fi
 
-if [ "$2" != "" ] && [ -f "$2/$LIBMAME" ]; then
+LIBMAME="libmame-$1.a"
+LIBMAME_URL="https://github.com/ToddLa/mame/releases/download/mame0231/$LIBMAME.gz"
+
+if [ -d "$2" ]; then
     echo COPY "$2/$LIBMAME"
     cp "$2/$LIBMAME" .
     exit
@@ -42,7 +48,6 @@ fi
 
 ## download from GitHub if no local version
 echo DOWNLOAD $LIBMAME
-curl -L "https://github.com/ToddLa/mame/releases/download/mame0231/$LIBMAME.gz" | gunzip > $LIBMAME
+curl -L $LIBMAME_URL | gunzip > $LIBMAME
 
-## echo "USAGE: $0 [ios | tvos | mac | all] [source]"
 

--- a/get-libmame.sh
+++ b/get-libmame.sh
@@ -42,7 +42,7 @@ fi
 
 ## download from GitHub if no local version
 echo DOWNLOAD $LIBMAME
-curl -L  curl -L "https://github.com/ToddLa/mame/releases/download/mame0231/$LIBMAME.gz" | gunzip > $LIBMAME
+curl -L "https://github.com/ToddLa/mame/releases/download/mame0231/$LIBMAME.gz" | gunzip > $LIBMAME
 
 ## echo "USAGE: $0 [ios | tvos | mac | all] [source]"
 

--- a/get-libmame.sh
+++ b/get-libmame.sh
@@ -32,7 +32,7 @@ if [ "$1" != "ios" ] && [ "$1" != "tvos" ] && [ "$1" != "mac" ]; then
 fi
 
 LIBMAME="libmame-$1.a"
-LIBMAME_URL="https://github.com/ToddLa/mame/releases/download/mame0231/$LIBMAME.gz"
+LIBMAME_URL="https://github.com/ToddLa/mame/releases/latest/download/$LIBMAME.gz"
 
 if [ -d "$2" ]; then
     echo COPY "$2/$LIBMAME"

--- a/iOS-res/help.md
+++ b/iOS-res/help.md
@@ -20,7 +20,7 @@ This version emulates over 8000 different romsets.
 
 Please, try to understand that that with that amount of games, some will run better than others and some might not even run with MAME4iOS Reloaded. Please, don't email me asking for a specific game to run.
 
-After installing, place your MAME-titled zipped roms in `/roms` folder, use iTunes file sharing, built in WebServer or AirDrop (select Open in MAME4iOS).
+After installing, place your MAME-titled zipped roms in the top folder, use iTunes file sharing, Files.app, built in WebServer or AirDrop (select Open in MAME4iOS).
 
 MAME4iOS Reloaded uses only '0.139u1' romset.
 
@@ -41,6 +41,7 @@ To see [MAME license](#MAME4iOS-LICENSE), go to the end of this document.
 *   MiFI, Xbox, and DualShock [Game Controlers](#game-controlers)
 *   [TV-OUT](#tv-out)
 *   [iCloud Import, Export, and Sync.](#iCloud)
+*   [Simple *smart* romset install](#ROM-INSTALLATION)
 
 ... and more.
 
@@ -365,9 +366,14 @@ To connect an iPad or iPhone to your TV or a projector, you can either use the A
 
 When the cable is connected to a TV or projector, MAME4iOS will automatically use it when playing a game.
 
+## ROM INSTALLATION
+
+use `Import...`, `Start Web Server`, or `Import from iCloud` from `MAME4iOS` `Settings` 
+
+
 ## MANUAL ROM INSTALLATION
 
-use iTunes file sharing (if your MAME4iOS build has it available) or use a 3rd party app like iFunBox or iExplorer to copy ROMs on sandboxed MAME4iOS 'Documents' folder:
+use iTunes file sharing (if your MAME4iOS build has it available) or Files.app, or a 3rd party app like iFunBox or iExplorer to copy ROMs on sandboxed MAME4iOS 'Documents' folder:
 
 Step 1\. Downloaded iFunBox (or a similar utility) and plug your iOS device into your computer.
 
@@ -376,6 +382,39 @@ Step 2\. Launch iFunBox and select your iOS device on the left hand side.
 Step 3\. click on apps icon. Now you should see a list of all of your device’s applications. Locate MAME4iOS, click it, and select Documents.
 
 Step 4\. And that’s all there is to it. Move your ROMs into this folder, launch MAME4iOS, and start playing!
+
+## Software Lists
+
+Software lists are containing meta-data of software for computers and consoles and are coming from various sources,
+they are not compiled in code but use as valuable source of information in order to preserve and document software.
+
+### How to add software to `MAME4iOS`
+
+* first import a *software list xml* file, you can find these files [here](https://github.com/mamedev/mame/tree/master/hash)
+    - you can also copy software list xml files *by hand* to the `hash` directory.
+* you might be tempted to just import *all* software list files, **dont** do that, it will waste diskspace on your device, and cause `MAME4iOS` to do extra work.
+* after you have imported the software list xml files, you can import `ZIP` files containing software. 
+
+If the name of the `ZIP` file *or* the subdirectory path in the `ZIP` matches the name of a software list, it will be imported directly, otherwise all software lists will be searched for a match.
+
+example zip file(s)
+```
+a2600.zip
+    pacman.zip
+    et.zip
+```
+
+```
+MySoftware.zip
+    a2600/pacman.zip
+    a2600/et.zip
+    n64/007goldnu.7z
+```
+
+## Mixing 139 and 2xx ROMs
+Some `romsets` are not compatible between MAME 139 and newer versions, the best way to use both `romsets` at the same time is to make sure the newer ones are stored in the `7z` format and the 139 ones in the `zip` format.  This way both files can co-exist.
+
+
 
 ## DIRECTORIES
 

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -291,7 +291,7 @@ static BOOL g_mame_warning_shown = FALSE;
 static BOOL g_no_roms_found = FALSE;
 
 #define OPTIONS_RELOAD_KEYS     @[@"filterClones", @"filterNotWorking", @"filterBIOS"]
-#define OPTIONS_RESTART_KEYS    @[@"cheats", @"autosave", @"emuspeed", @"hiscore", @"vbean2x", @"vflicker"]
+#define OPTIONS_RESTART_KEYS    @[@"cheats", @"autosave", /*@"emuspeed",*/ @"hiscore", @"vbean2x", @"vflicker"] 
 static NSInteger g_settings_roms_count;
 static NSInteger g_settings_file_count;
 static NSInteger g_settings_hash_count;

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -368,7 +368,7 @@ void m4i_output(int channel, const char* text)
 #endif
     
     // ignore this error
-    if (channel == MYOSD_OUTPUT_ERROR && strcmp(text, "Error opening translation file English") == 0)
+    if (channel == MYOSD_OUTPUT_ERROR && strstr(text, "Error opening translation file") != NULL)
         return;
     
     // capture any error/warning output for later use.
@@ -480,6 +480,8 @@ void* app_Thread_Start(void* args)
                 strncpy(g_mame_game_error, mame_game, sizeof(g_mame_game_error));
             else
                 snprintf(g_mame_game_error, sizeof(g_mame_game_error), "%s/%s", mame_system, mame_game);
+            
+            g_mame_game[0] = g_mame_system[0] = 0;
         }
         // we should always be asked to run a different game, if not (mame failed with no error) go back to the menu
         if (strcmp(mame_game, g_mame_game) == 0 && strcmp(mame_system, g_mame_system) == 0)

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -291,7 +291,7 @@ static BOOL g_mame_warning_shown = FALSE;
 static BOOL g_no_roms_found = FALSE;
 
 #define OPTIONS_RELOAD_KEYS     @[@"filterClones", @"filterNotWorking", @"filterBIOS"]
-#define OPTIONS_RESTART_KEYS    @[@"cheats", @"autosave", /*@"emuspeed",*/ @"hiscore", @"vbean2x", @"vflicker"] 
+#define OPTIONS_RESTART_KEYS    @[@"cheats", @"autosave", @"hiscore", @"vbean2x", @"vflicker"]
 static NSInteger g_settings_roms_count;
 static NSInteger g_settings_file_count;
 static NSInteger g_settings_hash_count;
@@ -1211,6 +1211,8 @@ HUDViewController* g_menu;
 }
 
 - (void)checkForNewRoms {
+    if (g_settings_options == nil)
+        return;
     NSInteger roms_count = [NSFileManager.defaultManager enumeratorAtPath:getDocumentPath(@"roms")].allObjects.count;
     NSInteger file_count = [NSFileManager.defaultManager contentsOfDirectoryAtPath:getDocumentPath(@"") error:nil].count;
     NSInteger hash_count = [NSFileManager.defaultManager contentsOfDirectoryAtPath:getDocumentPath(@"hash") error:nil].count;
@@ -1234,7 +1236,10 @@ HUDViewController* g_menu;
         [self reload];
     else if (myosd_inGame != 0 && ![g_settings_options isEqualToOptions:options withKeys:OPTIONS_RESTART_KEYS])
         [self restart]; // re-launch current game
-    
+    // TODO: fix MAME 2xx to support changing speed "on the fly"
+    else if (myosd_inGame != 0 && myosd_get(MYOSD_SPEED) == 0 && ![g_settings_options isEqualToOptions:options withKeys:@[@"emuspeed"]])
+        [self restart]; // re-launch current game
+
     g_settings_options = nil;
 }
 

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -2427,8 +2427,8 @@ static int handle_buttons(myosd_input_state* myosd)
         // TODO: fix keyboard for realz
         if (myosd_has_keyboard && myosd_inGame && !myosd_in_menu)
             g_mame_key = MYOSD_KEY_EXIT;    // this does a schedule_exit inside MAME
-        else if (myosd_exitGame == 2 || g_no_roms_found)
-            g_mame_key = MYOSD_KEY_ESC_2;   // push ESC twice incase a MAME msgbox is up.
+        else if (g_no_roms_found && myosd_get(MYOSD_VERSION) > 139)     // HACK!
+            g_mame_key = MYOSD_KEY_ESC_2;   // push ESC twice to dismiss msgbox.
         else
             g_mame_key = MYOSD_KEY_ESC;
         myosd_exitGame = 0;
@@ -4713,7 +4713,7 @@ BOOL is_roms_dir(NSString* dir) {
             [application.delegate application:application openURL:url options:@{UIApplicationOpenURLOptionsOpenInPlaceKey:@(NO)}];
             [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(moveROMS) object:nil];
         }
-        [self performSelectorOnMainThread:@selector(moveROMS) withObject:nil waitUntilDone:NO];
+        [self reload];
     }
     else {
         NSParameterAssert(urls.count == 1);
@@ -5621,7 +5621,7 @@ NSString* getGamepadSymbol(GCExtendedGamepad* gamepad, GCControllerElement* elem
         [[WebServer sharedInstance] webUploader].delegate = nil;
         [[WebServer sharedInstance] stopUploader];
         if (!myosd_inGame)
-            myosd_exitGame = 1;     /* exit mame menu and re-scan ROMs*/
+            [self reload];  /* exit mame menu and re-scan ROMs*/
     }]];
     alert.preferredAction = alert.actions.lastObject;
     g_web_server_alert = TRUE;
@@ -5780,8 +5780,9 @@ NSString* getGamepadSymbol(GCExtendedGamepad* gamepad, GCControllerElement* elem
             }]];
         }
         [alert addAction:[UIAlertAction actionWithTitle:@"Reload ROMs" style:UIAlertActionStyleCancel image:[UIImage systemImageNamed:@"arrow.2.circlepath.circle" withPointSize:size] handler:^(UIAlertAction * _Nonnull action) {
-            myosd_exitGame = 1;     /* exit mame menu and re-scan ROMs*/
+            [self reload];  /* exit mame menu and re-scan ROMs*/
         }]];
+        change_pause(PAUSE_INPUT);
         [self.topViewController presentViewController:alert animated:YES completion:nil];
         return;
     }

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -1751,7 +1751,7 @@ UIPressType input_debounce(unsigned long pad_status, CGPoint stick) {
     if (myosd_inGame || g_mame_game_info.gameName.length != 0)
         alpha = 1.0;
     else
-        alpha = 0.0;
+        alpha = DebugLog ? 0.5 : 0.0;
     
 #if TARGET_OS_IOS
     if (change_layout) {
@@ -2411,6 +2411,8 @@ static void push_mame_flush()
     myosd_exitGame = 0;
 }
 
+#define MYOSD_KEY_ESC_2 (MYOSD_KEY_ESC + (MYOSD_KEY_ESC<<8))
+#define MYOSD_KEY_ESC_4 (MYOSD_KEY_ESC_2 + (MYOSD_KEY_ESC_2<<16))
 
 // send buttons and keys - we do this inside of myosd_poll_input() because it is called from droid_ios_poll_input
 // ...and we are sure MAME is in a state to accept input, and not waking up from being paused or loading a ROM
@@ -2420,12 +2422,17 @@ static int handle_buttons(myosd_input_state* myosd)
 {
     // check for exitGame
     if (myosd_exitGame) {
-        NSCParameterAssert(g_mame_key == 0 || g_mame_key == MYOSD_KEY_ESC || g_mame_key == MYOSD_KEY_EXIT);
+        NSCParameterAssert(g_mame_key == 0 ||
+                           g_mame_key == MYOSD_KEY_EXIT ||
+                           g_mame_key == MYOSD_KEY_ESC ||
+                           g_mame_key == MYOSD_KEY_ESC_2 ||
+                           g_mame_key == MYOSD_KEY_ESC_4);
         // only force a hard exit on keyboard machines, else just use ESC
+        // TODO: fix keyboard for realz
         if (myosd_has_keyboard && myosd_inGame && !myosd_in_menu)
-            g_mame_key = MYOSD_KEY_EXIT;
+            g_mame_key = MYOSD_KEY_EXIT;    // this does a schedule_exit inside MAME
         else
-            g_mame_key = MYOSD_KEY_ESC;
+            g_mame_key = MYOSD_KEY_ESC_4;   // cram 4 ESCs down MAMEs input. (will reset in m4i_input_init)
         myosd_exitGame = 0;
     }
     

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -396,7 +396,7 @@ int run_mame(char* system, char* game)
         (game && game[0] != 0 && game[0] != ' ') ? game : "-nocoinlock",
         "-nocoinlock",
         g_pref_cheat ? "-cheat" : "-nocheat",
-        g_pref_autosave ? "-autosave" : "-noautosave",
+        g_pref_autosave ? "-autosave" : "-noautosave",      // TODO: this is not connected to any UI
         g_pref_showINFO ? "-noskip_gameinfo" : "-skip_gameinfo",
         "-speed", speed,
         g_pref_hiscore ? "-hiscore" : "-nohiscore",

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -2412,7 +2412,6 @@ static void push_mame_flush()
 }
 
 #define MYOSD_KEY_ESC_2 (MYOSD_KEY_ESC + (MYOSD_KEY_ESC<<8))
-#define MYOSD_KEY_ESC_4 (MYOSD_KEY_ESC_2 + (MYOSD_KEY_ESC_2<<16))
 
 // send buttons and keys - we do this inside of myosd_poll_input() because it is called from droid_ios_poll_input
 // ...and we are sure MAME is in a state to accept input, and not waking up from being paused or loading a ROM
@@ -2422,19 +2421,16 @@ static int handle_buttons(myosd_input_state* myosd)
 {
     // check for exitGame
     if (myosd_exitGame) {
-        NSCParameterAssert(g_mame_key == 0 ||
-                           g_mame_key == MYOSD_KEY_EXIT ||
-                           g_mame_key == MYOSD_KEY_ESC ||
-                           g_mame_key == MYOSD_KEY_ESC_2 ||
-                           g_mame_key == MYOSD_KEY_ESC_4);
+        NSCParameterAssert(g_mame_key == 0 || g_mame_key == MYOSD_KEY_EXIT ||
+                           g_mame_key == MYOSD_KEY_ESC || g_mame_key == MYOSD_KEY_ESC_2);
         // only force a hard exit on keyboard machines, else just use ESC
         // TODO: fix keyboard for realz
         if (myosd_has_keyboard && myosd_inGame && !myosd_in_menu)
             g_mame_key = MYOSD_KEY_EXIT;    // this does a schedule_exit inside MAME
-        else if (myosd_inGame)
-            g_mame_key = MYOSD_KEY_ESC;
+        else if (myosd_exitGame == 2 || g_no_roms_found)
+            g_mame_key = MYOSD_KEY_ESC_2;   // push ESC twice incase a MAME msgbox is up.
         else
-            g_mame_key = MYOSD_KEY_ESC_4;   // cram 4 ESCs down MAMEs input. (will reset in m4i_input_init)
+            g_mame_key = MYOSD_KEY_ESC;
         myosd_exitGame = 0;
     }
     

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -732,7 +732,7 @@ void m4i_game_stop()
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 + (NSDictionary*)getCurrentGame {
-    return [[NSUserDefaults standardUserDefaults] objectForKey:kSelectedGameInfoKey];
+    return [[NSUserDefaults standardUserDefaults] objectForKey:kSelectedGameInfoKey] ?: @{};
 }
 
 + (EmulatorController*)sharedInstance {

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -4549,7 +4549,7 @@ BOOL is_roms_dir(NSString* dir) {
     // now add ZIP files.
     for (NSString* file in files)
     {
-        if ([file isEqualToString:@"cheat.zip"])
+        if ([file.stringByDeletingPathExtension.lowercaseString isEqualToString:@"cheat"])
             continue;
         if ([file.pathExtension.lowercaseString isEqualToString:@"xml"])
             continue;

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -463,12 +463,11 @@ void* app_Thread_Start(void* args)
             g_mame_reset = FALSE;
         }
         
-        // copy the system+game we should run, and zero them out for next time.
+        // copy the system+game we should run
         char mame_system[sizeof(g_mame_system)];    // system MAME should run
         char mame_game[sizeof(g_mame_game)];        // game MAME should run (or empty is menu)
         strncpy(mame_system, g_mame_system, sizeof(mame_system));
         strncpy(mame_game, g_mame_game, sizeof(mame_game));
-        g_mame_game[0] = g_mame_system[0] = 0;
         
         BOOL running_game = mame_game[0] != 0;
         
@@ -482,6 +481,9 @@ void* app_Thread_Start(void* args)
             else
                 snprintf(g_mame_game_error, sizeof(g_mame_game_error), "%s/%s", mame_system, mame_game);
         }
+        // we should always be asked to run a different game, if not (mame failed with no error) go back to the menu
+        if (strcmp(mame_game, g_mame_game) == 0 && strcmp(mame_system, g_mame_system) == 0)
+            g_mame_game[0] = g_mame_system[0] = 0;
      }
     NSLog(@"thread exit");
     g_emulation_initiated = -1;
@@ -5662,6 +5664,10 @@ NSString* getGamepadSymbol(GCExtendedGamepad* gamepad, GCControllerElement* elem
     }
     else if (viewController != nil) {
         NSLog(@"CANT RUN GAME! (%@ is active)", viewController);
+        return;
+    }
+    else if ([game[kGameInfoName] isEqualToString:@(g_mame_game)] && [(game[kGameInfoSystem] ?: @"") isEqualToString:@(g_mame_system)]) {
+        NSLog(@"GAME IS ALREADY RUNNING! (%@/%@)", @(g_mame_system), @(g_mame_game));
         return;
     }
     

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -487,6 +487,7 @@ void* app_Thread_Start(void* args)
                 strncpy(g_mame_game_error, mame_game, sizeof(g_mame_game_error));
             else
                 snprintf(g_mame_game_error, sizeof(g_mame_game_error), "%s/%s", mame_system, mame_game);
+            g_mame_game[0] = g_mame_system[0] = 0;
         }
     }
     NSLog(@"thread exit");
@@ -1029,7 +1030,7 @@ HUDViewController* g_menu;
         // RESET and SERVICE
         [menu addButtons:@[@":power:Reset", @":wrench:Service"] style:HUDButtonStyleDefault handler:^(NSUInteger button) {
             if (button == 0)
-                push_mame_key(MYOSD_KEY_RESET);
+                push_mame_key(MYOSD_KEY_F3);    // SOFT reset
             else
                 push_mame_key(MYOSD_KEY_SERVICE);
         }];
@@ -2166,7 +2167,7 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 #else
         [hudView addButtons:@[@":power:Power", @":wrench:Service"] handler:^(NSUInteger button) {
             if (button == 0)
-                push_mame_key(MYOSD_KEY_RESET);         // this does a HARD reset
+                push_mame_key(MYOSD_KEY_F3);            // this does a SOFT reset
             else
                 push_mame_key(MYOSD_KEY_SERVICE);
         }];
@@ -2420,10 +2421,11 @@ static int handle_buttons(myosd_input_state* myosd)
     // check for exitGame
     if (myosd_exitGame) {
         NSCParameterAssert(g_mame_key == 0 || g_mame_key == MYOSD_KEY_ESC || g_mame_key == MYOSD_KEY_EXIT);
-        if (myosd_in_menu)
-            g_mame_key = MYOSD_KEY_ESC;
-        else
+        // only force a hard exit on keyboard machines, else just use ESC
+        if (myosd_has_keyboard && myosd_inGame && !myosd_in_menu)
             g_mame_key = MYOSD_KEY_EXIT;
+        else
+            g_mame_key = MYOSD_KEY_ESC;
         myosd_exitGame = 0;
     }
     
@@ -3439,7 +3441,7 @@ void m4i_input_poll(myosd_input_state* myosd, size_t input_size) {
     push_mame_key(MYOSD_KEY_P);
 }
 -(void)mameReset {
-    push_mame_key(MYOSD_KEY_RESET);
+    push_mame_key(MYOSD_KEY_F3);    // SOFT reset
 }
 -(void)mameFullscreen {
     [self commandKey:'\r'];

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -2421,7 +2421,7 @@ static int handle_buttons(myosd_input_state* myosd)
         if (myosd_has_keyboard && myosd_inGame && !myosd_in_menu)
             g_mame_key = MYOSD_KEY_EXIT;    // this does a schedule_exit inside MAME
         else if (g_no_roms_found && myosd_get(MYOSD_VERSION) > 139)     // HACK!
-            g_mame_key = MYOSD_KEY_ESC_2;   // push ESC twice to dismiss msgbox.
+            g_mame_key = MYOSD_KEY_EXIT;    // force an exit to dismiss msgbox.
         else
             g_mame_key = MYOSD_KEY_ESC;
         myosd_exitGame = 0;

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -4639,9 +4639,8 @@ BOOL is_roms_dir(NSString* dir) {
             continue;
         
         // TODO: 7z for artwork and samples?
-        NSArray* paths = @[@"artwork/%@.zip", @"samples/%@.zip", @"titles/%@.png", @"cfg/%@.cfg", @"ini/%@.ini", @"sta/%@/1.sta", @"sta/%@/2.sta", @"hi/%@.hi"];
+        NSArray* paths = @[@"roms/%@.zip", @"roms/%@.7z", @"artwork/%@.zip", @"samples/%@.zip", @"titles/%@.png", @"cfg/%@.cfg", @"ini/%@.ini", @"sta/%@/1.sta", @"sta/%@/2.sta", @"hi/%@.hi"];
 
-        [files addObject:rom];
         for (NSString* path in paths) {
             NSString* file = [NSString stringWithFormat:path, rom.stringByDeletingPathExtension];
             if ([NSFileManager.defaultManager fileExistsAtPath:[rootPath stringByAppendingPathComponent:file]])

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -2431,6 +2431,8 @@ static int handle_buttons(myosd_input_state* myosd)
         // TODO: fix keyboard for realz
         if (myosd_has_keyboard && myosd_inGame && !myosd_in_menu)
             g_mame_key = MYOSD_KEY_EXIT;    // this does a schedule_exit inside MAME
+        else if (myosd_inGame)
+            g_mame_key = MYOSD_KEY_ESC;
         else
             g_mame_key = MYOSD_KEY_ESC_4;   // cram 4 ESCs down MAMEs input. (will reset in m4i_input_init)
         myosd_exitGame = 0;

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -921,6 +921,16 @@ HUDViewController* g_menu;
     
     if(myosd_inGame && myosd_in_menu==0)
     {
+        // if there are zero Start buttons, check for a 2600  // TODO: remove this hack.
+        if (myosd_num_players == 0 && [g_mame_game_info.gameSystem isEqualToString:@"a2600"]) {
+            [menu addButtons:@[@"Select", @"Start"] style:HUDButtonStyleDefault handler:^(NSUInteger button) {
+                if (button == 0)
+                    push_mame_key(MYOSD_KEY_1);
+                else
+                    push_mame_key(MYOSD_KEY_2);
+            }];
+        }
+
         // myosd_num_players counts the number of Start buttons, if there are zero Start buttons, we cant do anything!
         if (myosd_num_players == 1) {
             // 1P Start

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -4394,11 +4394,6 @@ BOOL is_roms_dir(NSString* dir) {
 
     NSString* toPath = nil;
     
-    // dont barf on a 7z file, just pretend enumeration worked, and found nothing interesting inside
-    if (!result && [romName.pathExtension.lowercaseString isEqualToString:@"7z"]) {
-        result = TRUE;
-    }
-
     if (!result)
     {
         NSLog(@"%@ is a CORRUPT ZIP (deleting)", romPath);
@@ -4581,6 +4576,11 @@ BOOL is_roms_dir(NSString* dir) {
     BOOL first_boot = [files_to_import containsObject:@"cheat0139.zip"];
 
     if (!first_boot) {
+        
+        // HACK: wait til any other VC is presented, sigh
+        if (self.presentedViewController.isBeingPresented)
+            return [self performSelector:_cmd withObject:nil afterDelay:1.0];
+        
         progressAlert = [UIAlertController alertControllerWithTitle:@"Moving ROMs" message:@"Please wait..." preferredStyle:UIAlertControllerStyleAlert];
         [progressAlert setProgress:0.0 text:@""];
         [self.topViewController presentViewController:progressAlert animated:YES completion:nil];

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -3384,13 +3384,15 @@ void m4i_input_poll(myosd_input_state* myosd, size_t input_size) {
         NSLog(@"canPerformAction: %@: %d", NSStringFromSelector(action), !g_emulation_paused && [self presentedViewController] == nil);
         return !g_emulation_paused && [self presentedViewController] == nil;
     }
-    
+
+#if TARGET_OS_IOS
     if (action == @selector(paste:)) {
         BOOL can_paste = !g_emulation_paused && [self presentedViewController] == nil &&
                 myosd_has_keyboard && UIPasteboard.generalPasteboard.hasStrings;
         NSLog(@"canPaste: %d", can_paste);
         return can_paste;
     }
+#endif
 
     return [super canPerformAction:action withSender:sender];
 }

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -1301,12 +1301,12 @@ HUDViewController* g_menu;
     
     g_pref_keep_aspect_ratio = [op keepAspectRatio];
     
-    g_pref_filter = [Options.arrayFilter optionName:op.filter];
-    g_pref_screen_shader = [Options.arrayScreenShader optionName:op.screenShader];
-    g_pref_line_shader = [Options.arrayLineShader optionName:op.lineShader];
+    g_pref_filter = [Options.arrayFilter optionFind:op.filter];
+    g_pref_screen_shader = [Options.arrayScreenShader optionFind:op.screenShader];
+    g_pref_line_shader = [Options.arrayLineShader optionFind:op.lineShader];
     [self loadShader];
 
-    g_pref_skin = [Options.arraySkin optionName:op.skin];
+    g_pref_skin = [Options.arraySkin optionFind:op.skin];
     [skinManager setCurrentSkin:g_pref_skin];
 
     g_pref_integer_scale_only = op.integerScalingOnly;
@@ -1880,34 +1880,15 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
 
 // get the current shader (friendly) name
 -(NSString*)getShaderName {
-    NSString* shader_name = myosd_isVector ? g_pref_line_shader : g_pref_screen_shader;
-    NSArray* shader_list = myosd_isVector ? Options.arrayLineShader : Options.arrayScreenShader;
-
-    // HACK: assume the 3rd shader is the actual default, None is 2nd
-    if (([shader_name isEqualToString:kScreenViewShaderDefault] || shader_name.length == 0) && shader_list.count >= 3) {
-        NSParameterAssert([shader_list[0] isEqualToString:kScreenViewShaderDefault]);
-        NSParameterAssert([shader_list[1] isEqualToString:kScreenViewShaderNone]);
-        shader_name =  [NSString stringWithFormat:@"%@ (%@)", kScreenViewShaderDefault, split(shader_list[2],@":").firstObject];
-    }
-
-   return shader_name;
+    return myosd_isVector ? g_pref_line_shader : g_pref_screen_shader;
 }
 
 // get the current shader, maping Default to the actual shader
 -(NSString*)getShader {
-    
-    NSString* shader_name = myosd_isVector ? g_pref_line_shader : g_pref_screen_shader;
-    NSArray* shader_list = myosd_isVector ? Options.arrayLineShader : Options.arrayScreenShader;
-    NSString* shader = [shader_list optionData:shader_name];
-    
-    // HACK: assume the 3rd shader is the actual default, None is 2nd
-    if (([shader_name isEqualToString:kScreenViewShaderDefault] || shader_name.length == 0) && shader_list.count >= 3) {
-        NSParameterAssert([shader_list[0] isEqualToString:kScreenViewShaderDefault]);
-        NSParameterAssert([shader_list[1] isEqualToString:kScreenViewShaderNone]);
-        shader = split(shader_list[2],@":").lastObject;
-    }
-    
-    return shader;
+    if (myosd_isVector)
+        return [MetalScreenView getLineShader:g_pref_line_shader];
+    else
+        return [MetalScreenView getScreenShader:g_pref_screen_shader];
 }
 
 // save the current shader variables to disk
@@ -3282,8 +3263,8 @@ void m4i_input_poll(myosd_input_state* myosd, size_t input_size) {
     
     NSDictionary* options = @{
         kScreenViewFilter: g_pref_filter,
-        kScreenViewScreenShader: [Options.arrayScreenShader optionData:g_pref_screen_shader],
-        kScreenViewLineShader: [Options.arrayLineShader optionData:g_pref_line_shader],
+        kScreenViewScreenShader: g_pref_screen_shader,
+        kScreenViewLineShader: g_pref_line_shader,
     };
     
     // the reason we dont re-create screenView each time is because we access screenView from background threads

--- a/iOS/KeyboardView.m
+++ b/iOS/KeyboardView.m
@@ -687,6 +687,12 @@ int hid_to_mame(int keyCode) {
         mame_map[UIKeyboardHIDUsageKeyboardApplication] = MYOSD_KEY_INVALID;
         mame_map[UIKeyboardHIDUsageKeyboardPower      ] = MYOSD_KEY_INVALID;
         
+#ifdef DEBUG
+        // HACK: map backslash to SCRLOCK to test keyboards
+        // TODO: remove this....
+        mame_map[UIKeyboardHIDUsageKeyboardBackslash   ] = MYOSD_KEY_SCRLOCK;
+#endif
+        
 #else   // provide a minimal set of keys for Xcode < 11.4
         
         for (int i=0; i<26; i++)

--- a/iOS/ListOptionController.m
+++ b/iOS/ListOptionController.m
@@ -55,12 +55,8 @@
     if (self = [super initWithStyle:UITableViewStyleGrouped])
     {
         NSAssert([[[Options alloc] init] valueForKey:keyValue] != nil, @"bad key");
-        
         key = keyValue;
-        list = [listValue mutableCopy];
-        // if the list items are of the form "Name : Data", we only want to show "Name" to the user.
-        for (NSInteger i=0; i<list.count; i++)
-            ((NSMutableArray*)list)[i] = [[list[i] componentsSeparatedByString:@":"].firstObject stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+        list = listValue;
     }
     return self;
 }

--- a/iOS/MetalScreenView.h
+++ b/iOS/MetalScreenView.h
@@ -46,5 +46,9 @@
 
 @interface MetalScreenView : MetalView <ScreenView>
 
+// get the actual shaders used for a given name, used by the HUD to edit params
++ (Shader)getScreenShader:(NSString*)name;
++ (Shader)getLineShader:(NSString*)name;
+
 @end
 

--- a/iOS/MetalScreenView.m
+++ b/iOS/MetalScreenView.m
@@ -92,7 +92,9 @@ TIMER_INIT_END
 // SCREEN SHADER
 //
 // Metal shader string is of the form:
-//        <Friendly Name> : <shader description>
+//        @"<Friendly Name>", @"<shader description>"
+//
+// the first shader in this list is used the Default
 //
 // NOTE: see MetalView.h for what a <shader description> is.
 // in addition to the <shader description> in MetalView.h you can specify a named variable like so....
@@ -113,9 +115,8 @@ TIMER_INIT_END
 //
 //  Presets are simply the @string without the key names, only numbers!
 //
-+ (NSArray*)screenShaderList {
-    return @[kScreenViewShaderDefault, kScreenViewShaderNone,
-             @"simpleTron: simpleCRT, mame-screen-dst-rect, mame-screen-src-rect,\
++ (NSArray*)screenShaders {
+    return @[@"simpleTron", @"simpleCRT, mame-screen-dst-rect, mame-screen-src-rect,\
                             Vertical Curvature = 5.0 1.0 10.0 0.1,\
                             Horizontal Curvature = 4.0 1.0 10.0 0.1,\
                             Curvature Strength = 0.25 0.0 1.0 0.05,\
@@ -123,7 +124,7 @@ TIMER_INIT_END
                             Vignette Strength = 0.05 0.0 1.0 0.05,\
                             Zoom Factor = 1.0 0.01 5.0 0.1,\
                             Brightness Factor = 1.0 0.0 2.0",
-             @"megaTron : megaTron, mame-screen-src-rect, mame-screen-dst-rect,\
+             @"megaTron", @"megaTron, mame-screen-src-rect, mame-screen-dst-rect,\
                             Shadow Mask Type = 3.0 0.0 3.0 1.0,\
                             Shadow Mask Intensity = 0.5 0.0 1.0 0.05,\
                             Scanline Thinness = 0.7 0.0 1.0 0.05,\
@@ -132,13 +133,13 @@ TIMER_INIT_END
                             Use Trinitron-style Curvature = 0.0 0.0 1.0 1.0,\
                             CRT Corner Roundness = 3.0 2.0 11.0 1.0,\
                             CRT Gamma = 2.9 0.0 5.0 0.1",
-             @"megaTron - Shadow Mask Strong: megaTron, mame-screen-src-rect, mame-screen-dst-rect,3.0,0.75,0.6,1.4,0.02,1.0,2.0,3.0",
-             @"megaTron - Vertical Games (Use Linear Filter): megaTron, mame-screen-src-rect, mame-screen-dst-rect,3.0,0.4,0.8,3.0,0.02,0.0,3.0,2.9",
-             @"megaTron - Grille Mask: megaTron, mame-screen-src-rect, mame-screen-dst-rect,2.0,0.85,0.6,2.0,0.02,1.0,2.0,3.0",
-             @"megaTron - Grille Mask Lite: megaTron, mame-screen-src-rect, mame-screen-dst-rect,1.0,0.6,0.6,1.6,0.02,1.0,2.0,2.8",
-             @"megaTron - No Shadow Mask but Blurred: megaTron, mame-screen-src-rect, mame-screen-dst-rect,0.0,0.6,0.6,1.0,0.02,0.0,2.0,2.6",
+             @"megaTron - Shadow Mask Strong", @"megaTron, mame-screen-src-rect, mame-screen-dst-rect,3.0,0.75,0.6,1.4,0.02,1.0,2.0,3.0",
+             @"megaTron - Vertical Games (Use Linear Filter)", @"megaTron, mame-screen-src-rect, mame-screen-dst-rect,3.0,0.4,0.8,3.0,0.02,0.0,3.0,2.9",
+             @"megaTron - Grille Mask", @"megaTron, mame-screen-src-rect, mame-screen-dst-rect,2.0,0.85,0.6,2.0,0.02,1.0,2.0,3.0",
+             @"megaTron - Grille Mask Lite", @"megaTron, mame-screen-src-rect, mame-screen-dst-rect,1.0,0.6,0.6,1.6,0.02,1.0,2.0,2.8",
+             @"megaTron - No Shadow Mask but Blurred", @"megaTron, mame-screen-src-rect, mame-screen-dst-rect,0.0,0.6,0.6,1.0,0.02,0.0,2.0,2.6",
              
-             @"ulTron : ultron,\
+             @"ulTron ", @"ultron,\
                         mame-screen-src-rect,\
                         mame-screen-dst-rect,\
                         Scanline Sharpness = -6.0 -20.0 0.0 1.0,\
@@ -154,16 +155,30 @@ TIMER_INIT_END
                         Glow Amount = 0.15 0.0 1.0 0.05,\
                         Phosphor Focus = 1.75 0.0 10.0 0.05",
              
+             kScreenViewShaderNone, ShaderTexture,
+             
 #ifdef DEBUG
-             @"Wombat1: mame_screen_test, mame-screen-size, frame-count, 1.0, 8.0, 8.0",
-             @"Wombat2: mame_screen_test, mame-screen-size, frame-count, wombat_rate=2.0, wombat_u=16.0, wombat_v=16.0",
-             @"Test (dot): mame_screen_dot, mame-screen-matrix",
-             @"Test (scanline): mame_screen_line, mame-screen-matrix",
-             @"Test (rainbow): mame_screen_rainbow, mame-screen-matrix, frame-count, rainbow_h = 16.0 4.0 32.0 1.0, rainbow_speed = 1.0 1.0 16.0",
-             @"Test (color): texture, blend=copy, color-test-pattern=1 0 1 1, test-brightness-factor=1.0 1.0 4.0",
+             @"Wombat1", @"mame_screen_test, mame-screen-size, frame-count, 1.0, 8.0, 8.0",
+             @"Wombat2", @"mame_screen_test, mame-screen-size, frame-count, wombat_rate=2.0, wombat_u=16.0, wombat_v=16.0",
+             @"Test (dot)", @"mame_screen_dot, mame-screen-matrix",
+             @"Test (scanline)", @"mame_screen_line, mame-screen-matrix",
+             @"Test (rainbow)", @"mame_screen_rainbow, mame-screen-matrix, frame-count, rainbow_h = 16.0 4.0 32.0 1.0, rainbow_speed = 1.0 1.0 16.0",
+             @"Test (color)", @"texture, blend=copy, color-test-pattern=1 0 1 1, test-brightness-factor=1.0 1.0 4.0",
 #endif
     ];
 }
+
++ (NSArray*)screenShaderList {
+    return [self.screenShaders filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"NOT (self CONTAINS ',')"]];
+}
++ (Shader)getScreenShader:(NSString*)name {
+    NSInteger idx = [self.screenShaders indexOfObject:name];
+    if (idx == NSNotFound) idx = 0;     // use the first shader as a default
+    return self.screenShaders[idx + 1];
+}
+
+
+
 
 // LINE SHADER - a line shader is exactly like a screen shader.
 //
@@ -188,24 +203,35 @@ TIMER_INIT_END
 //      `line-time` == 0.0  - lines for the current frame
 //      `line-time` > 0.0   - lines for past frames (line-time is the number of seconds in the past)
 //
-+ (NSArray*)lineShaderList {
-    return @[kScreenViewShaderDefault, kScreenViewShaderNone,
-        @"lineTron: lineTron, blend=alpha, fade-width-scale=1.2 0.1 8, line-time, fade-falloff=3 1 8, fade-strength = 0.2 0.1 3.0 0.1",
++ (NSArray*)lineShaders {
+    return @[
+        @"lineTron", @"lineTron, blend=alpha, fade-width-scale=1.2 0.1 8, line-time, fade-falloff=3 1 8, fade-strength = 0.2 0.1 3.0 0.1",
+             
+        kScreenViewShaderNone, ShaderNone,
 
 #ifdef DEBUG
-        @"Dash: mame_test_vector_dash, blend=add, width-scale=1.0 0.25 6.0, frame-count, length=25.0, speed=16.0",
-        @"Dash (Fast): mame_test_vector_dash, blend=add, 1.0, frame-count, 15.0, 16.0",
-        @"Dash (Slow): mame_test_vector_dash, blend=add, 1.0, frame-count, 15.0, 2.0",
+        @"Dash",         @"mame_test_vector_dash, blend=add, width-scale=1.0 0.25 6.0, frame-count, length=25.0, speed=16.0",
+        @"Dash (Fast)",  @"mame_test_vector_dash, blend=add, 1.0, frame-count, 15.0, 16.0",
+        @"Dash (Slow)",  @"mame_test_vector_dash, blend=add, 1.0, frame-count, 15.0, 2.0",
                  
-        @"Pulse: mame_test_vector_pulse, blend=add, width-scale=1.0 0.25 6.0, frame-count, rate=2.0",
-        @"Pulse (Fast): mame_test_vector_pulse, blend=add, 1.0, frame-count, 0.5",
-        @"Pulse (Slow): mame_test_vector_pulse, blend=add, 1.0, frame-count, 2.0",
+        @"Pulse",        @"mame_test_vector_pulse, blend=add, width-scale=1.0 0.25 6.0, frame-count, rate=2.0",
+        @"Pulse (Fast)", @"mame_test_vector_pulse, blend=add, 1.0, frame-count, 0.5",
+        @"Pulse (Slow)", @"mame_test_vector_pulse, blend=add, 1.0, frame-count, 2.0",
 
-        @"Fade (Alpha): mame_test_vector_fade, blend=alpha, fade-width-scale=1.2 1 8, line-time, fade-falloff=2 1 4, fade-strength = 0.5 0.1 3.0 0.1",
-        @"Fade (Add):   mame_test_vector_fade, blend=add,   fade-width-scale=1.2 1 8, line-time, fade-falloff=2 1 4, fade-strength = 0.5 0.1 3.0 0.1",
+        @"Fade (Alpha)", @"mame_test_vector_fade, blend=alpha, fade-width-scale=1.2 1 8, line-time, fade-falloff=2 1 4, fade-strength = 0.5 0.1 3.0 0.1",
+        @"Fade (Add)",   @"mame_test_vector_fade, blend=add,   fade-width-scale=1.2 1 8, line-time, fade-falloff=2 1 4, fade-strength = 0.5 0.1 3.0 0.1",
 #endif
     ];
 }
++ (NSArray*)lineShaderList {
+    return [self.lineShaders filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"NOT (self CONTAINS ',')"]];
+}
++ (Shader)getLineShader:(NSString*)name {
+    NSInteger idx = [self.lineShaders indexOfObject:name];
+    if (idx == NSNotFound) idx = 0;     // use the first shader as a default
+    return self.lineShaders[idx + 1];
+}
+
 + (NSArray*)filterList {
     return @[kScreenViewFilterLinear, kScreenViewFilterNearest];
 }
@@ -241,32 +267,10 @@ static NSMutableArray* split(NSString* str, NSString* sep) {
         _filter = MTLSamplerMinMagFilterLinear;
 
     // get the shader to use when drawing the SCREEN, default to the 3 entry in the list (simpleTron).
-    NSString* screen_shader = _options[kScreenViewScreenShader] ?: kScreenViewShaderDefault;
-
-    NSParameterAssert([MetalScreenView.screenShaderList[0] isEqualToString:kScreenViewShaderDefault]);
-    NSParameterAssert([MetalScreenView.screenShaderList[1] isEqualToString:kScreenViewShaderNone]);
-    NSParameterAssert(MetalScreenView.screenShaderList.count > 2);
-    if ([screen_shader length] == 0 || [screen_shader isEqualToString:kScreenViewShaderDefault])
-        screen_shader = split(MetalScreenView.screenShaderList[2], @":").lastObject;
-
-    if ([screen_shader isEqualToString:kScreenViewShaderNone])
-        screen_shader = ShaderTexture;
-    
-    _screen_shader = screen_shader;
+    _screen_shader = [MetalScreenView getScreenShader:_options[kScreenViewScreenShader]];
 
     // get the shader to use when drawing VECTOR lines, default to lineTron
-    NSString* line_shader = _options[kScreenViewLineShader] ?: kScreenViewShaderDefault;
-    
-    NSParameterAssert([MetalScreenView.lineShaderList[0] isEqualToString:kScreenViewShaderDefault]);
-    NSParameterAssert([MetalScreenView.lineShaderList[1] isEqualToString:kScreenViewShaderNone]);
-    NSParameterAssert(MetalScreenView.lineShaderList.count > 2);
-    if ([line_shader length] == 0 || [line_shader isEqualToString:kScreenViewShaderDefault])
-        line_shader = split(MetalScreenView.lineShaderList[2], @":").lastObject;
-
-    if ([line_shader isEqualToString:kScreenViewShaderNone])
-        line_shader = nil;
-    
-    _line_shader = line_shader;
+    _line_shader = [MetalScreenView getLineShader:_options[kScreenViewLineShader]];
     
     // see if the line shader wants past lines, ie does it list `line-time` in the parameter list.x
     _line_shader_wants_past_lines = [_line_shader rangeOfString:@"line-time"].length != 0;
@@ -584,7 +588,7 @@ static void load_texture_prim(id<MTLTexture> texture, myosd_render_primitive* pr
         }
         else if (prim->type == MYOSD_RENDER_PRIMITIVE_LINE) {
             // wide line, if the blendmode is ADD this is a VECTOR line, else a UI line.
-            if (prim->blendmode == MYOSD_BLENDMODE_ADD && _line_shader != nil) {
+            if (prim->blendmode == MYOSD_BLENDMODE_ADD && _line_shader != ShaderNone) {
                 // this line is a vector line, use a special shader
 
                 // pre-multiply color, so shader has non-iterated color

--- a/iOS/MetalScreenView.m
+++ b/iOS/MetalScreenView.m
@@ -94,15 +94,14 @@ TIMER_INIT_END
 // Metal shader string is of the form:
 //        @"<Friendly Name>", @"<shader description>"
 //
-// the first shader in this list is used the Default
+// the first shader in this list is used the *Default*
 //
 // NOTE: see MetalView.h for what a <shader description> is.
 // in addition to the <shader description> in MetalView.h you can specify a named variable like so....
 //
-//       variable_name = <default value> <min value> <max value> <step value>
-//
-//  you dont use commas to separate values, use spaces.
-//  min, max, and step are all optional, and only effect the InfoHUD, MetalView ignores them.
+//      variable_name = <default value> <min value> <max value> <step value>
+//          dont use commas to separate values, use spaces.
+//          min, max, and step are all optional, and only effect the InfoHUD, MetalView ignores them.
 //
 //  the following variables are pre-defined by MetalView and MetalScreenView
 //
@@ -155,7 +154,7 @@ TIMER_INIT_END
                         Glow Amount = 0.15 0.0 1.0 0.05,\
                         Phosphor Focus = 1.75 0.0 10.0 0.05",
              
-             kScreenViewShaderNone, ShaderTexture,
+             @"None", ShaderTexture,
              
 #ifdef DEBUG
              @"Wombat1", @"mame_screen_test, mame-screen-size, frame-count, 1.0, 8.0, 8.0",
@@ -169,6 +168,7 @@ TIMER_INIT_END
 }
 
 + (NSArray*)screenShaderList {
+    // return only the shader names, shaders will have a comma
     return [self.screenShaders filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"NOT (self CONTAINS ',')"]];
 }
 + (Shader)getScreenShader:(NSString*)name {
@@ -207,7 +207,7 @@ TIMER_INIT_END
     return @[
         @"lineTron", @"lineTron, blend=alpha, fade-width-scale=1.2 0.1 8, line-time, fade-falloff=3 1 8, fade-strength = 0.2 0.1 3.0 0.1",
              
-        kScreenViewShaderNone, ShaderNone,
+        @"None", ShaderNone,
 
 #ifdef DEBUG
         @"Dash",         @"mame_test_vector_dash, blend=add, width-scale=1.0 0.25 6.0, frame-count, length=25.0, speed=16.0",
@@ -224,6 +224,7 @@ TIMER_INIT_END
     ];
 }
 + (NSArray*)lineShaderList {
+    // return only the shader names, shaders will have a comma
     return [self.lineShaders filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"NOT (self CONTAINS ',')"]];
 }
 + (Shader)getLineShader:(NSString*)name {
@@ -463,7 +464,6 @@ static void load_texture_prim(id<MTLTexture> texture, myosd_render_primitive* pr
 
 #pragma mark - draw MAME primitives
 
-// return 1 if you handled the draw, 0 for a software render
 // NOTE this is called on MAME background thread, dont do anything stupid.
 - (void)drawScreen:(void*)prim_list size:(CGSize)size {
     static Shader shader_map[] = {ShaderNone, ShaderAlpha, ShaderMultiply, ShaderAdd};

--- a/iOS/OptionsController.m
+++ b/iOS/OptionsController.m
@@ -123,28 +123,28 @@
                 {
                     cell.textLabel.text = @"Filter";
                     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                    cell.detailTextLabel.text = [Options.arrayFilter optionName:op.filter];
+                    cell.detailTextLabel.text = [Options.arrayFilter optionFind:op.filter];
                     break;
                 }
                 case 1:
                 {
                     cell.textLabel.text   = @"Skin";
                     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                    cell.detailTextLabel.text = [Options.arraySkin optionName:op.skin];
+                    cell.detailTextLabel.text = [Options.arraySkin optionFind:op.skin];
                     break;
                 }
                 case 2:
                 {
                     cell.textLabel.text   = @"Screen Shader";
                     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                    cell.detailTextLabel.text = [Options.arrayScreenShader optionName:op.screenShader];
+                    cell.detailTextLabel.text = [Options.arrayScreenShader optionFind:op.screenShader];
                     break;
                 }
                 case 3:
                 {
                     cell.textLabel.text   = @"Vector Shader";
                     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                    cell.detailTextLabel.text = [Options.arrayLineShader optionName:op.lineShader];
+                    cell.detailTextLabel.text = [Options.arrayLineShader optionFind:op.lineShader];
                     break;
                 }
                case 4:

--- a/iOS/OptionsTableViewController.m
+++ b/iOS/OptionsTableViewController.m
@@ -83,10 +83,10 @@
     
     const char * myosd_version = (const char *)myosd_get(MYOSD_VERSION_STRING) ?: "";
     // get the mame version from MYOSD, and remove any date in ()s
-    NSString* mame_version = [[NSString stringWithUTF8String:myosd_version] componentsSeparatedByString:@" ("].firstObject;
+    NSString* mame_version = [@(myosd_version) componentsSeparatedByString:@" ("].firstObject;
     
     if (mame_version.length != 0)
-        version = [NSString stringWithFormat:@"%@ • %@", version, mame_version];
+        version = [NSString stringWithFormat:@"%@ • MAME %@", version, mame_version];
 
     // this is the last date Info.plist was modifed, if you do a clean build, or change the version, it is the build date.
 #if TARGET_OS_MACCATALYST
@@ -123,7 +123,7 @@
     else if (git_commit)
         build_info = [NSString stringWithFormat:@"%@ (%@)", build_date, git_commit];
 
-    return [NSString stringWithFormat:@"%@ • %@\n%@\n%@", display_name, version, bundle_ident, build_info];
+    return [NSString stringWithFormat:@"%@ %@\n%@\n%@", display_name, version, bundle_ident, build_info];
 }
 
 #if TARGET_OS_TV

--- a/iOS/ScreenView.h
+++ b/iOS/ScreenView.h
@@ -60,12 +60,9 @@
 
 @protocol ScreenView <NSObject>
 
-// the Settings UI will let the user choose from these, format of a entry is is:
+// the Settings UI will let the user choose from these
 //
-//      <Friendly Name> : <Data>
-//
-// only the <Friendly Name> will be shown to the user, the <Data> will be passed
-// in the setOptions: NSDictionary
+// the string will be passed in the setOptions: NSDictionary
 //
 + (NSArray<NSString*>*)filterList;
 + (NSArray<NSString*>*)screenShaderList;

--- a/iOS/ScreenView.h
+++ b/iOS/ScreenView.h
@@ -55,9 +55,6 @@
 #define kScreenViewFilterNearest    @"Nearest"
 #define kScreenViewFilterLinear     @"Linear"
 
-#define kScreenViewShaderNone       @"None"
-#define kScreenViewShaderDefault    @"Default"
-
 @protocol ScreenView <NSObject>
 
 // the Settings UI will let the user choose from these

--- a/src/osd/droid-ios/libmame.h
+++ b/src/osd/droid-ios/libmame.h
@@ -47,6 +47,8 @@ enum MYOSD_AXIS {
 };
 
 #define NUM_JOY 4
+#define NUM_MICE 4
+#define NUM_GUN 4
 #define NUM_KEYS 256
 
 // MYOSD INPUT STATE
@@ -59,13 +61,13 @@ typedef struct {
     float joy_analog[NUM_JOY][MYOSD_AXIS_NUM];
 
     // mice
-    unsigned long mouse_status[NUM_JOY];
+    unsigned long mouse_status[NUM_MICE];
     float mouse_x[NUM_JOY];
     float mouse_y[NUM_JOY];
     float mouse_z[NUM_JOY];
 
     // lightgun(s)
-    unsigned long lightgun_status[NUM_JOY];
+    unsigned long lightgun_status[NUM_GUN];
     float lightgun_x[NUM_JOY];
     float lightgun_y[NUM_JOY];
     

--- a/src/osd/droid-ios/osd-ios.c
+++ b/src/osd/droid-ios/osd-ios.c
@@ -69,6 +69,12 @@ int myosd_main(int argc, char** argv, myosd_callbacks* callbacks, size_t callbac
     return ios_main(argc, argv);
 }
 
+// myosd_enumerate_7z - placeholder function, MAME 139 does not support 7z archives, so just fail.
+extern "C" int myosd_enumerate_7z(const char* path, int load_data_flag, void* callback_ptr, void (*callback)(void* callback_ptr, const uint16_t* name, size_t len, const uint8_t* data, size_t size))
+{
+    return -1;
+}
+
 // myosd_get
 intptr_t myosd_get(int var)
 {

--- a/src/osd/droid-ios/osdinput.c
+++ b/src/osd/droid-ios/osdinput.c
@@ -242,7 +242,7 @@ void my_poll_ports(running_machine *machine)
                     myosd_input.num_mouse = 1;
                 if(field->type == IPT_LIGHTGUN_X)
                     myosd_input.num_lightgun = 1;
-                if(field->type == IPT_KEYBOARD || field->type == IPT_KEYPAD)
+                if(field->type == IPT_KEYBOARD)
                     myosd_input.num_keyboard = 1;
             }
         }

--- a/src/osd/droid-ios/osdvideo.c
+++ b/src/osd/droid-ios/osdvideo.c
@@ -30,30 +30,12 @@ void droid_ios_init_video(running_machine *machine)
 	curr_vis_height = 0;
 }
 
-// HACK function to get current view from render target
-// TODO: move it into render.c??
-// TODO: make a function called render_target_has_art()??
-layout_view * render_target_get_current_view(render_target *target)
-{
-    //return target->curview;
-    return (layout_view *)((void**)target)[2];
-}
-
 void droid_ios_video_render(render_target *our_target)
 {
     int vis_width,vis_height;
     int min_width,min_height;
     render_target_get_minimum_size(our_target, &min_width, &min_height);
-    
-    int has_art = layout_view_has_art(render_target_get_current_view(our_target));
-    int in_menu = ui_is_menu_active();
-
-    // if the current view has artwork, or a menu we want to use the largest target we can, to fit the display
-    // ...otherwise use the minimal buffer size needed, so it gets scaled up by hardware.
-    if (has_art || in_menu)
-        render_target_compute_visible_area(our_target,MAX(640,myosd_display_width),MAX(480,myosd_display_height),1.0,render_target_get_orientation(our_target),&vis_width, &vis_height);
-    else
-        render_target_compute_visible_area(our_target,MAX(min_width,min_height),MAX(min_width,min_height),1.0,render_target_get_orientation(our_target),&vis_width, &vis_height);
+    render_target_compute_visible_area(our_target,MAX(640,myosd_display_width),MAX(480,myosd_display_height),1.0,render_target_get_orientation(our_target),&vis_width, &vis_height);
     
     // check for a change in the min-size of render target *or* size of the vis screen
     if (min_width != curr_min_width || min_height != curr_min_height ||

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -65,7 +65,7 @@
 #define CELL_SHADOW_COLOR       UIColor.clearColor
 #define CELL_BACKGROUND_COLOR   UIColor.clearColor
 
-#define CELL_SELECTED_SHADOW_COLOR       self.tintColor
+#define CELL_SELECTED_SHADOW_COLOR       [self.tintColor colorWithAlphaComponent:0.333]
 #define CELL_SELECTED_BACKGROUND_COLOR   UIColor.clearColor
 
 #define CELL_CORNER_RADIUS      16.0
@@ -845,6 +845,7 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
         else {
             cell.backgroundView = nil;
             cell.contentView.backgroundColor = HEADER_BACKGROUND_COLOR;
+            cell.selected = cell.selected;  // update selected/focused state
         }
     }
 }
@@ -2457,7 +2458,7 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
     }
     [self setBackgroundColor:selected ? CELL_SELECTED_BACKGROUND_COLOR : CELL_BACKGROUND_COLOR];
 #if TARGET_OS_TV
-    [_image.layer setBorderWidth:1.0 / UIScreen.mainScreen.scale];
+    [_image.layer setBorderWidth:1.0];
     [_image.layer setBorderColor:(selected ? CELL_SELECTED_SHADOW_COLOR : UIColor.clearColor).CGColor];
 #else
     [self setShadowColor:selected ? CELL_SELECTED_SHADOW_COLOR : CELL_SHADOW_COLOR];

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -65,7 +65,7 @@
 #define CELL_SHADOW_COLOR       UIColor.clearColor
 #define CELL_BACKGROUND_COLOR   UIColor.clearColor
 
-#define CELL_SELECTED_COLOR      self.tintColor
+#define CELL_SELECTED_SHADOW_COLOR       self.tintColor
 #define CELL_SELECTED_BACKGROUND_COLOR   UIColor.clearColor
 
 #define CELL_CORNER_RADIUS      16.0
@@ -2449,7 +2449,7 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
     BOOL selected = self.selected || self.focused;
     if (_image.image == nil) {
 #if TARGET_OS_TV
-        // GameInfoController will change this class
+        // GameInfoController will change this class, so ignore that case
         if ([_text isKindOfClass:[UILabel class]])
             self.contentView.backgroundColor = selected ? HEADER_SELECTED_COLOR : HEADER_BACKGROUND_COLOR;
 #endif
@@ -2457,10 +2457,10 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
     }
     [self setBackgroundColor:selected ? CELL_SELECTED_BACKGROUND_COLOR : CELL_BACKGROUND_COLOR];
 #if TARGET_OS_TV
-    [_image.layer setBorderWidth:4.0];
-    [_image.layer setBorderColor:(selected ? CELL_SELECTED_COLOR : UIColor.clearColor).CGColor];
+    [_image.layer setBorderWidth:1.0 / UIScreen.mainScreen.scale];
+    [_image.layer setBorderColor:(selected ? CELL_SELECTED_SHADOW_COLOR : UIColor.clearColor).CGColor];
 #else
-    [self setShadowColor:selected ? CELL_SELECTED_COLOR : CELL_SHADOW_COLOR];
+    [self setShadowColor:selected ? CELL_SELECTED_SHADOW_COLOR : CELL_SHADOW_COLOR];
 #endif
     CGFloat scale = selected ? _scale : self.highlighted ? (2.0 - _scale) : 1.0;
     _stackView.transform = CGAffineTransformMakeScale(scale, scale);

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -65,8 +65,10 @@
 #define CELL_SHADOW_COLOR       UIColor.clearColor
 #define CELL_BACKGROUND_COLOR   UIColor.clearColor
 
-#define CELL_SELECTED_SHADOW_COLOR       [self.tintColor colorWithAlphaComponent:0.333]
-#define CELL_SELECTED_BACKGROUND_COLOR   UIColor.clearColor
+#define CELL_SELECTED_SHADOW_COLOR      UIColor.clearColor
+#define CELL_SELECTED_BACKGROUND_COLOR  UIColor.clearColor
+#define CELL_SELECTED_BORDER_COLOR      [self.tintColor colorWithAlphaComponent:0.500]
+#define CELL_SELECTED_BORDER_WIDTH      1.0
 
 #define CELL_CORNER_RADIUS      16.0
 #define CELL_BORDER_WIDTH       0.0
@@ -2456,13 +2458,14 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
 #endif
         return;
     }
+    
     [self setBackgroundColor:selected ? CELL_SELECTED_BACKGROUND_COLOR : CELL_BACKGROUND_COLOR];
-#if TARGET_OS_TV
-    [_image.layer setBorderWidth:1.0];
-    [_image.layer setBorderColor:(selected ? CELL_SELECTED_SHADOW_COLOR : UIColor.clearColor).CGColor];
-#else
     [self setShadowColor:selected ? CELL_SELECTED_SHADOW_COLOR : CELL_SHADOW_COLOR];
-#endif
+    
+    if (CELL_SELECTED_BORDER_COLOR != UIColor.clearColor) {
+        [_image.layer setBorderWidth:selected ? CELL_SELECTED_BORDER_WIDTH : 0.0];
+        [_image.layer setBorderColor:(selected ? CELL_SELECTED_BORDER_COLOR : UIColor.clearColor).CGColor];
+    }
     CGFloat scale = selected ? _scale : self.highlighted ? (2.0 - _scale) : 1.0;
     _stackView.transform = CGAffineTransformMakeScale(scale, scale);
 #if TARGET_OS_TV

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -299,6 +299,12 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
     [seg2 addTarget:self action:@selector(scopeChange:) forControlEvents:UIControlEventValueChanged];
     UIBarButtonItem* scope = [[UIBarButtonItem alloc] initWithCustomView:seg2];
     
+#if TARGET_OS_TV
+    UIColor* color = UIApplication.sharedApplication.keyWindow.tintColor;
+    [seg2 setTitleTextAttributes:@{NSForegroundColorAttributeName:color} forState:UIControlStateNormal];
+    [seg2 setTitleTextAttributes:@{NSForegroundColorAttributeName:color} forState:UIControlStateSelected];
+#endif
+    
     // settings
     UIImage* settingsImage = [UIImage systemImageNamed:@"gear" withPointSize:height] ?: [[UIImage imageNamed:@"menu"] scaledToSize:CGSizeMake(height, height)];
 #if TARGET_OS_TV

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -10,6 +10,7 @@
 #import "ChooseGameController.h"
 #import "PopupSegmentedControl.h"
 #import "GameInfo.h"
+#import "SoftwareList.h"
 #import "ImageCache.h"
 #import "SystemImage.h"
 #import "InfoDatabase.h"
@@ -1556,6 +1557,15 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
     if (all) {
         for (NSString* file in @[@"roms/%@.zip", @"roms/%@.7z", @"roms/%@/", @"artwork/%@.zip", @"samples/%@.zip"])
             [files addObject:[NSString stringWithFormat:file, name]];
+    }
+
+    // if we are a parent ROM include all of our clones
+    if (game.gameParent.length <= 1 && all) {
+        NSArray* clones = [_gameList filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"gameSystem == %@ && gameParent == %@", game.gameSystem, game.gameName]];
+        for (NSDictionary* clone in clones) {
+            // TODO: check if this is a merged romset??
+            [files addObjectsFromArray:[self getGameFiles:clone allFiles:YES]];
+        }
     }
     
     return files;

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -1809,7 +1809,7 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
 
 // get the title for the ContextMenu
 - (NSString*)menuTitleForGame:(NSDictionary *)game {
-    return [ChooseGameController getGameText:game].string;
+    return [ChooseGameController getGameText:game layoutMode:LayoutList].string;
 }
 - (NSString*)menuTitleForItemAtIndexPath:(NSIndexPath *)indexPath {
     return [self menuTitleForGame:[self getGameInfo:indexPath]];

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -75,14 +75,16 @@
 #if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST)
 #define CELL_TITLE_FONT         [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline]
 #define CELL_TITLE_COLOR        [UIColor whiteColor]
+#define CELL_CLONE_COLOR        [UIColor colorWithWhite:0.555 alpha:1.0]
 #define CELL_DETAIL_FONT        [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote]
-#define CELL_DETAIL_COLOR       [UIColor lightGrayColor]
+#define CELL_DETAIL_COLOR       [UIColor colorWithWhite:0.333 alpha:1.0]
 #define CELL_MAX_LINES          3
 #else   // tvOS and mac
 #define CELL_TITLE_FONT         [UIFont boldSystemFontOfSize:20.0]
 #define CELL_TITLE_COLOR        [UIColor whiteColor]
+#define CELL_CLONE_COLOR        [UIColor colorWithWhite:0.555 alpha:1.0]
 #define CELL_DETAIL_FONT        [UIFont systemFontOfSize:20.0]
-#define CELL_DETAIL_COLOR       [UIColor lightGrayColor]
+#define CELL_DETAIL_COLOR       [UIColor colorWithWhite:0.333 alpha:1.0]
 #define CELL_MAX_LINES          3
 #endif
 
@@ -1103,7 +1105,7 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
 //  romname     short Description           Description                 Description
 //              short Manufacturer • Year   short Manufacturer • Year   Manufacturer • Year  • romname [parent-rom]
 //
-+(NSAttributedString*)getGameText:(NSDictionary*)info layoutMode:(LayoutMode)layoutMode textAlignment:(NSTextAlignment)textAlignment badge:(NSString*)badge
++(NSAttributedString*)getGameText:(NSDictionary*)info layoutMode:(LayoutMode)layoutMode textAlignment:(NSTextAlignment)textAlignment badge:(NSString*)badge clone:(BOOL)clone
 {
     NSString* title;
     NSString* detail;
@@ -1151,7 +1153,7 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
 
     NSMutableAttributedString* text = [[NSMutableAttributedString alloc] initWithString:title attributes:@{
         NSFontAttributeName:CELL_TITLE_FONT,
-        NSForegroundColorAttributeName:CELL_TITLE_COLOR
+        NSForegroundColorAttributeName:clone ? CELL_CLONE_COLOR : CELL_TITLE_COLOR
     }];
 
     if (detail != nil)
@@ -1198,7 +1200,7 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
 
 +(NSAttributedString*)getGameText:(NSDictionary*)game layoutMode:(LayoutMode)layoutMode
 {
-    return [self getGameText:game layoutMode:layoutMode textAlignment:NSTextAlignmentCenter badge:nil];
+    return [self getGameText:game layoutMode:layoutMode textAlignment:NSTextAlignmentCenter badge:nil clone:NO];
 }
 
 +(NSAttributedString*)getGameText:(NSDictionary*)game
@@ -1210,7 +1212,8 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
 {
     return [[self class] getGameText:game layoutMode:_layoutMode
                        textAlignment:_layoutMode == LayoutList ? NSTextAlignmentLeft : CELL_TEXT_ALIGN
-                               badge:[self isFavorite:game] ? @"star.fill" : @""];
+                               badge:[self isFavorite:game] ? @"star.fill" : @""
+                               clone:game.gameParent.length != 0];
 }
 
 // compute the size(s) of a single item. returns: (x = image_height, y = text_height)

--- a/xcode/MAME4iOS/GCDWebUploader/GCDWebUploader.bundle/en.lproj/Localizable.strings
+++ b/xcode/MAME4iOS/GCDWebUploader/GCDWebUploader.bundle/en.lproj/Localizable.strings
@@ -1,3 +1,3 @@
-"PROLOGUE" = "<p>Drag &amp; drop files on this window or use the \"Upload Files&hellip;\" button to upload new files.</p>";
+"PROLOGUE" = "<p>Drag &amp; drop files on this window or use the \"Upload Files&hellip;\" button to upload new files.</p><p><b>NOTE</b> files copied directly into <code>roms</code> will not be *smart* imported.</b></p>";
 "EPILOGUE" = "";
 "FOOTER_FORMAT" = "%@ %@";

--- a/xcode/MAME4iOS/GameInfo.h
+++ b/xcode/MAME4iOS/GameInfo.h
@@ -68,6 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSArray<NSURL*>* gameImageURLs;
 
 @property (nonatomic, readonly) BOOL gameIsFake;
+@property (nonatomic, readonly) BOOL gameIsMame;
 
 @end
 

--- a/xcode/MAME4iOS/GameInfo.h
+++ b/xcode/MAME4iOS/GameInfo.h
@@ -29,11 +29,13 @@
 #define kGameInfoMameInfo       @"mameinfo"
 #define kGameInfoSoftware       @"software"         // list of supported software for system
 #define kGameInfoSoftwareList   @"softlist"         // this game is *from* a software list
+#define kGameInfoFile           @"file"
 
 #define kGameInfoTypeArcade     @"Arcade"
 #define kGameInfoTypeConsole    @"Console"
 #define kGameInfoTypeComputer   @"Computer"
 #define kGameInfoTypeBIOS       @"BIOS"
+#define kGameInfoTypeSnapshot   @"Snapshot"
 
 #define kGameInfoScreenHorizontal   @"Horizontal"
 #define kGameInfoScreenVertical     @"Vertical"
@@ -60,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSString* gameCategory;
 @property (nonatomic, strong, readonly) NSString* gameSoftware;
 @property (nonatomic, strong, readonly) NSString* gameSoftwareList;
+@property (nonatomic, strong, readonly) NSString* gameFile;
 
 @property (nonatomic, strong, readonly) NSString* gameTitle;
 @property (nonatomic, strong, readonly) NSURL* gameImageURL;
@@ -69,6 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL gameIsFake;
 @property (nonatomic, readonly) BOOL gameIsMame;
+@property (nonatomic, readonly) BOOL gameIsSnapshot;
 
 @end
 

--- a/xcode/MAME4iOS/GameInfo.h
+++ b/xcode/MAME4iOS/GameInfo.h
@@ -73,6 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL gameIsFake;
 @property (nonatomic, readonly) BOOL gameIsMame;
 @property (nonatomic, readonly) BOOL gameIsSnapshot;
+@property (nonatomic, readonly) BOOL gameIsClone;
 
 @end
 

--- a/xcode/MAME4iOS/GameInfo.m
+++ b/xcode/MAME4iOS/GameInfo.m
@@ -74,6 +74,10 @@
 {
     return [self.gameType isEqualToString:kGameInfoTypeSnapshot];
 }
+- (BOOL)gameIsClone
+{
+    return self.gameParent.length > 1;  // parent can be "0"
+}
 -(NSString*)gameTitle
 {
     return [(self[kGameInfoDescription] ?: self[kGameInfoName] ?: @"") componentsSeparatedByString:@" ("].firstObject;

--- a/xcode/MAME4iOS/GameInfo.m
+++ b/xcode/MAME4iOS/GameInfo.m
@@ -66,6 +66,14 @@
 {
     return [self.gameName isEqualToString:kGameInfoNameMameMenu];
 }
+- (NSString*)gameFile
+{
+    return self[kGameInfoFile] ?: @"";
+}
+- (BOOL)gameIsSnapshot
+{
+    return [self.gameType isEqualToString:kGameInfoTypeSnapshot];
+}
 -(NSString*)gameTitle
 {
     return [(self[kGameInfoDescription] ?: self[kGameInfoName] ?: @"") componentsSeparatedByString:@" ("].firstObject;
@@ -76,8 +84,11 @@
     NSParameterAssert(self.gameName.length != 0);
     NSParameterAssert(![self.gameName containsString:@" "]);
     NSParameterAssert(![self.gameSystem containsString:@" "]);
-
-    if (self.gameSoftwareList.length != 0)
+    
+    if (self.gameIsFake || self.gameIsSnapshot) {
+        return @[self.gameLocalImageURL];
+    }
+    else if (self.gameSoftwareList.length != 0)
     {
         /// MESS style title url
         /// http://adb.arcadeitalia.net/media/mess.current/titles/a2600/adventur.png
@@ -146,7 +157,9 @@
     NSString *path = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
 #endif
     
-    if (self.gameSoftwareList.length != 0)
+    if (self.gameIsSnapshot)
+        return [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/snap/%@", path, self.gameFile] isDirectory:NO];
+    else if (self.gameSoftwareList.length != 0)
         return [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/titles/%@/%@.png", path, self.gameSoftwareList, name] isDirectory:NO];
     else
         return [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/titles/%@.png", path, name] isDirectory:NO];

--- a/xcode/MAME4iOS/GameInfo.m
+++ b/xcode/MAME4iOS/GameInfo.m
@@ -62,6 +62,10 @@
 {
     return [@[kGameInfoNameMameMenu, kGameInfoNameSettings] containsObject:self[kGameInfoName]];
 }
+- (BOOL)gameIsMame
+{
+    return [self.gameName isEqualToString:kGameInfoNameMameMenu];
+}
 -(NSString*)gameTitle
 {
     return [(self[kGameInfoDescription] ?: self[kGameInfoName] ?: @"") componentsSeparatedByString:@" ("].firstObject;

--- a/xcode/MAME4iOS/MAME4iOS.xcconfig
+++ b/xcode/MAME4iOS/MAME4iOS.xcconfig
@@ -15,17 +15,17 @@
 //    you can also set the Development Team via the drop down in the Xcode project editor, for each Target.
 //    you can find your TeamID [here](https://developer.apple.com/account/#/membership)
 
-ORG_IDENTIFIER          = app.toddla    // CHANGE this to your Organization Identifier.
-DEVELOPMENT_TEAM        = 8RUN83V8CA    // CHANGE this to your Team ID. (or select in Xcode project editor)
-CURRENT_PROJECT_VERSION = 2021.7
-MARKETING_VERSION       = 2021.7
+ORG_IDENTIFIER          = com.example   // CHANGE this to your Organization Identifier.
+DEVELOPMENT_TEAM        = ABC8675309    // CHANGE this to your Team ID. (or select in Xcode project editor)
+CURRENT_PROJECT_VERSION = 2021.6
+MARKETING_VERSION       = 2021.6
 
 // 2. enable or disable entitlements
 //    tvOS TopShelf and iCloud import/export require special app entitlements
 
 ENTITLEMENTS_TYPE = -Base
 // UN-COMMENT NEXT LINE if you want a build with full entitlements
-ENTITLEMENTS_TYPE = -Full
+// ENTITLEMENTS_TYPE = -Full
 // UN-COMMENT PREV LINE if you want a build with full entitlements
 
 // these should not be changed.

--- a/xcode/MAME4iOS/MAME4iOS.xcconfig
+++ b/xcode/MAME4iOS/MAME4iOS.xcconfig
@@ -15,17 +15,17 @@
 //    you can also set the Development Team via the drop down in the Xcode project editor, for each Target.
 //    you can find your TeamID [here](https://developer.apple.com/account/#/membership)
 
-ORG_IDENTIFIER          = com.example   // CHANGE this to your Organization Identifier.
-DEVELOPMENT_TEAM        = ABC8675309    // CHANGE this to your Team ID. (or select in Xcode project editor)
-CURRENT_PROJECT_VERSION = 2021.6
-MARKETING_VERSION       = 2021.6
+ORG_IDENTIFIER          = app.toddla    // CHANGE this to your Organization Identifier.
+DEVELOPMENT_TEAM        = 8RUN83V8CA    // CHANGE this to your Team ID. (or select in Xcode project editor)
+CURRENT_PROJECT_VERSION = 2021.7
+MARKETING_VERSION       = 2021.7
 
 // 2. enable or disable entitlements
 //    tvOS TopShelf and iCloud import/export require special app entitlements
 
 ENTITLEMENTS_TYPE = -Base
 // UN-COMMENT NEXT LINE if you want a build with full entitlements
-// ENTITLEMENTS_TYPE = -Full
+ENTITLEMENTS_TYPE = -Full
 // UN-COMMENT PREV LINE if you want a build with full entitlements
 
 // these should not be changed.

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
@@ -491,7 +491,6 @@
 		CEE680CD163B147100051BC2 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		CEE680D1163BE5C400051BC2 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		E9856CEF23C9A7C50071666D /* MultipeerConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MultipeerConnectivity.framework; path = System/Library/Frameworks/MultipeerConnectivity.framework; sourceTree = SDKROOT; };
-		EF02B5BA2652D4D10089135D /* droid-ios */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "droid-ios"; path = "../../src/osd/droid-ios"; sourceTree = "<group>"; };
 		EF06A576248064AC00A974B8 /* Timer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Timer.h; sourceTree = "<group>"; };
 		EF1628122624ACC800E2B2AB /* libmame-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmame-ios.a"; path = "../../libmame-ios.a"; sourceTree = "<group>"; };
 		EF16284F2627433300E2B2AB /* libmame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = libmame.h; path = "../../../src/osd/droid-ios/libmame.h"; sourceTree = "<group>"; };
@@ -841,7 +840,6 @@
 				EF9F9C9E240070E700352554 /* README.md */,
 				EFFBA6FD24F1C91200F8666B /* WHATSNEW.md */,
 				EFE0036C264C0B0D00E42246 /* TODO.md */,
-				EF02B5BA2652D4D10089135D /* droid-ios */,
 				CEAC6C2716AAA73900AF3275 /* RELOADED */,
 				EF8E427B24900FE40049C84C /* UIKit Classes */,
 				92A5338421EBDBAD0089FBB9 /* GCDWebServer */,
@@ -1184,21 +1182,17 @@
 				ORGANIZATIONNAME = Seleuco;
 				TargetAttributes = {
 					925ABCA41E46DCC500997182 = {
-						DevelopmentTeam = 8RUN83V8CA;
 						LastSwiftMigration = 1200;
 						ProvisioningStyle = Automatic;
 					};
 					92ECB8EA21EA984D00D1E3D0 = {
 						CreatedOnToolsVersion = 10.1;
-						DevelopmentTeam = 8RUN83V8CA;
 						ProvisioningStyle = Automatic;
 					};
 					EFA7A0DE24B65C020009CF88 = {
-						DevelopmentTeam = 8RUN83V8CA;
 					};
 					EFEEA4B025C9D41E00314132 = {
 						CreatedOnToolsVersion = 12.4;
-						DevelopmentTeam = 8RUN83V8CA;
 						ProvisioningStyle = Automatic;
 					};
 				};

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
@@ -1183,17 +1183,13 @@
 				TargetAttributes = {
 					925ABCA41E46DCC500997182 = {
 						LastSwiftMigration = 1200;
-						ProvisioningStyle = Automatic;
 					};
 					92ECB8EA21EA984D00D1E3D0 = {
 						CreatedOnToolsVersion = 10.1;
 						ProvisioningStyle = Automatic;
 					};
-					EFA7A0DE24B65C020009CF88 = {
-					};
 					EFEEA4B025C9D41E00314132 = {
 						CreatedOnToolsVersion = 12.4;
-						ProvisioningStyle = Automatic;
 					};
 				};
 			};

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 		CEE680CD163B147100051BC2 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		CEE680D1163BE5C400051BC2 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		E9856CEF23C9A7C50071666D /* MultipeerConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MultipeerConnectivity.framework; path = System/Library/Frameworks/MultipeerConnectivity.framework; sourceTree = SDKROOT; };
+		EF02B5BA2652D4D10089135D /* droid-ios */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "droid-ios"; path = "../../src/osd/droid-ios"; sourceTree = "<group>"; };
 		EF06A576248064AC00A974B8 /* Timer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Timer.h; sourceTree = "<group>"; };
 		EF1628122624ACC800E2B2AB /* libmame-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmame-ios.a"; path = "../../libmame-ios.a"; sourceTree = "<group>"; };
 		EF16284F2627433300E2B2AB /* libmame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = libmame.h; path = "../../../src/osd/droid-ios/libmame.h"; sourceTree = "<group>"; };
@@ -840,6 +841,7 @@
 				EF9F9C9E240070E700352554 /* README.md */,
 				EFFBA6FD24F1C91200F8666B /* WHATSNEW.md */,
 				EFE0036C264C0B0D00E42246 /* TODO.md */,
+				EF02B5BA2652D4D10089135D /* droid-ios */,
 				CEAC6C2716AAA73900AF3275 /* RELOADED */,
 				EF8E427B24900FE40049C84C /* UIKit Classes */,
 				92A5338421EBDBAD0089FBB9 /* GCDWebServer */,
@@ -1182,14 +1184,22 @@
 				ORGANIZATIONNAME = Seleuco;
 				TargetAttributes = {
 					925ABCA41E46DCC500997182 = {
+						DevelopmentTeam = 8RUN83V8CA;
 						LastSwiftMigration = 1200;
+						ProvisioningStyle = Automatic;
 					};
 					92ECB8EA21EA984D00D1E3D0 = {
 						CreatedOnToolsVersion = 10.1;
+						DevelopmentTeam = 8RUN83V8CA;
 						ProvisioningStyle = Automatic;
+					};
+					EFA7A0DE24B65C020009CF88 = {
+						DevelopmentTeam = 8RUN83V8CA;
 					};
 					EFEEA4B025C9D41E00314132 = {
 						CreatedOnToolsVersion = 12.4;
+						DevelopmentTeam = 8RUN83V8CA;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};

--- a/xcode/MAME4iOS/MetalView.h
+++ b/xcode/MAME4iOS/MetalView.h
@@ -7,7 +7,7 @@
 //
 #import <UIKit/UIKit.h>
 #import <Metal/Metal.h>
-#import <simd/SIMD.h>
+#import <simd/simd.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/xcode/MAME4iOS/Options.h
+++ b/xcode/MAME4iOS/Options.h
@@ -18,6 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)resetOptions;
 + (void)setOption:(id)value forKey:(NSString*)key;
 
+@property (readonly) NSUInteger hash;
+- (BOOL)isEqual:(id)object;
+
 @property (class, readonly, strong) NSString* optionsFile;
 
 @property (class, readonly, strong) NSArray* arrayEmuSpeed;

--- a/xcode/MAME4iOS/Options.h
+++ b/xcode/MAME4iOS/Options.h
@@ -107,9 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
 // find and return option index given a name, default to first if not found
 - (NSUInteger)indexOfOption:(NSString*)string;
 // find and return option name given a string, default to first if not found
-- (NSString*)optionName:(NSString*)string;
-// find and return option data given a string, default to first if not found
-- (NSString*)optionData:(NSString*)string;
+- (NSString*)optionFind:(NSString*)string;
 @end
 
 

--- a/xcode/MAME4iOS/Options.h
+++ b/xcode/MAME4iOS/Options.h
@@ -18,8 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)resetOptions;
 + (void)setOption:(id)value forKey:(NSString*)key;
 
-@property (readonly) NSUInteger hash;
-- (BOOL)isEqual:(id)object;
+// compare two Options, but only the specified keys
+- (BOOL)isEqualToOptions:(Options*)other withKeys:(NSArray<NSString*>*)keys;
 
 @property (class, readonly, strong) NSString* optionsFile;
 

--- a/xcode/MAME4iOS/Options.m
+++ b/xcode/MAME4iOS/Options.m
@@ -358,31 +358,11 @@
 }
 // find and return option index given a name, default to first if not found
 - (NSUInteger)indexOfOption:(NSString*)string {
-    NSParameterAssert(![string containsString:@":"]); // a name should never contain the data.
-    // option lists are of the form "Name : Data" or just "Name"
-    for (NSUInteger idx=0; idx<self.count; idx++) {
-        NSString* str = [self[idx] componentsSeparatedByString:@":"].firstObject;
-        if ([string isEqualToString:[str stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet]])
-            return idx;
-    }
-    return 0;
-}
-// find and return option data given a string, default to first if not found
-- (NSString*)optionData:(NSString*)string {
-
-    NSString* str = [self optionAtIndex:[self indexOfOption:string]];
-    str = [str componentsSeparatedByString:@":"].lastObject;
-    str = [str stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-
-    return str;
+    NSUInteger idx = [self indexOfObject:string];
+    return (idx == NSNotFound) ? 0 : idx;
 }
 // find and return option name given a string, default to first if not found
-- (NSString*)optionName:(NSString*)string {
-
-    NSString* str = [self optionAtIndex:[self indexOfOption:string]];
-    str = [str componentsSeparatedByString:@":"].firstObject;
-    str = [str stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-    
-    return str;
+- (NSString*)optionFind:(NSString*)string {
+    return [self optionAtIndex:[self indexOfOption:string]];
 }
 @end

--- a/xcode/MAME4iOS/Options.m
+++ b/xcode/MAME4iOS/Options.m
@@ -327,24 +327,19 @@
     [data writeToFile:Options.optionsPath atomically:NO];
 }
 
-// hash and isEqual
--(NSUInteger)hash {
-    // we need to do our own hash, cuz Dictionary hash is just the count!
-    NSDictionary* optionsDict = [self getDictionary];
-    NSUInteger prime = 137;
-    NSUInteger result = [optionsDict hash];
-    for (NSObject *key in [[optionsDict allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
-        result = prime * result + [key hash];
-        result = prime * result + [optionsDict[key] hash];
+// compare two Options, but only the specified keys
+- (BOOL)isEqualToOptions:(Options*)other withKeys:(NSArray<NSString*>*)keys {
+
+    NSDictionary* lhs = [self getDictionary];
+    NSDictionary* rhs = [other getDictionary];
+
+    for (NSString* key in keys) {
+        id a = lhs[key];
+        id b = rhs[key];
+        if (!(a == b || [a isEqual:b]))
+            return FALSE;
     }
-    return result;
-}
-- (BOOL)isEqual:(id)object {
-    
-    if (![object isKindOfClass:[self class]])
-        return FALSE;
-    
-    return [[self getDictionary] isEqual:[object getDictionary]];
+    return TRUE;
 }
 
 @end

--- a/xcode/MAME4iOS/Options.m
+++ b/xcode/MAME4iOS/Options.m
@@ -246,9 +246,9 @@
     
 }
 
-- (void)saveOptions
+- (NSDictionary*)getDictionary
 {
-    NSDictionary* optionsDict = [NSDictionary dictionaryWithObjectsAndKeys:
+    return [NSDictionary dictionaryWithObjectsAndKeys:
                              [NSString stringWithFormat:@"%d", _keepAspectRatio], @"KeepAspect",
                               
                              _filter, @"filter",
@@ -317,11 +317,34 @@
                              [NSString stringWithFormat:@"%d", _hapticButtonFeedback], @"hapticButtonFeedback",
                                  
                              nil];
-    
-    
+}
+
+- (void)saveOptions
+{
+    NSDictionary* optionsDict = [self getDictionary];
     NSData* data = [NSPropertyListSerialization dataWithPropertyList:optionsDict format:NSPropertyListBinaryFormat_v1_0 options:0 error:nil];
     NSParameterAssert(data != nil);
     [data writeToFile:Options.optionsPath atomically:NO];
+}
+
+// hash and isEqual
+-(NSUInteger)hash {
+    // we need to do our own hash, cuz Dictionary hash is just the count!
+    NSDictionary* optionsDict = [self getDictionary];
+    NSUInteger prime = 137;
+    NSUInteger result = [optionsDict hash];
+    for (NSObject *key in [[optionsDict allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+        result = prime * result + [key hash];
+        result = prime * result + [optionsDict[key] hash];
+    }
+    return result;
+}
+- (BOOL)isEqual:(id)object {
+    
+    if (![object isKindOfClass:[self class]])
+        return FALSE;
+    
+    return [[self getDictionary] isEqual:[object getDictionary]];
 }
 
 @end

--- a/xcode/MAME4iOS/SoftwareList.h
+++ b/xcode/MAME4iOS/SoftwareList.h
@@ -10,6 +10,7 @@
 
 // keys used in a software list xml
 #define kSoftwareListName           @"name"
+#define kSoftwareListParent         @"cloneof"
 #define kSoftwareListYear           @"year"
 #define kSoftwareListDescription    @"description"
 #define kSoftwareListPublisher      @"publisher"

--- a/xcode/MAME4iOS/SoftwareList.h
+++ b/xcode/MAME4iOS/SoftwareList.h
@@ -33,6 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 // install a XML or ZIP file
 - (BOOL)installFile:(NSString*)path;
 
+// if this a merged romset, extract clones as empty zip files so they show up as Available
+- (BOOL)extractClones:(NSString*)path;
+
 // discard any cached data, forcing a re-load from disk.
 - (void)reload;
 

--- a/xcode/MAME4iOS/SoftwareList.h
+++ b/xcode/MAME4iOS/SoftwareList.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<NSDictionary*>*)getSoftwareList:(NSString*)name;
 
 // get games for a system
-- (NSArray<NSDictionary*>*)getGamesForSystem:(NSString*)system fromList:(NSString*)list;
+- (NSArray<NSDictionary*>*)getGamesForSystem:(NSDictionary*)system;
 
 // install a XML or ZIP file
 - (BOOL)installFile:(NSString*)path;

--- a/xcode/MAME4iOS/SoftwareList.m
+++ b/xcode/MAME4iOS/SoftwareList.m
@@ -145,8 +145,7 @@
             continue;
         
         // create a empty zip with the name of the clone.
-        // TODO: should we create a empty 7z for 7z files??
-        NSString* clone_path = [[path.stringByDeletingLastPathComponent stringByAppendingPathComponent:clone] stringByAppendingPathExtension:@"zip" /* path.pathExtension*/];
+        NSString* clone_path = [[path.stringByDeletingLastPathComponent stringByAppendingPathComponent:clone] stringByAppendingPathExtension:path.pathExtension];
         
         if (![NSFileManager.defaultManager fileExistsAtPath:clone_path]) {
             NSLog(@"....CREATING CLONE: %@", clone);

--- a/xcode/MAME4iOS/SoftwareList.m
+++ b/xcode/MAME4iOS/SoftwareList.m
@@ -10,7 +10,7 @@
 #import "ZipFile.h"
 #import "GameInfo.h"
 
-#define DebugLog 1
+#define DebugLog 0
 #if DebugLog == 0 || !defined(DEBUG)
 #define NSLog(...) (void)0
 #endif
@@ -341,7 +341,7 @@ static NSArray<NSString*>* getZipFiles(NSString* path) {
         return FALSE;
     }]];
 
-#if DebugLog != 0
+#if defined(DEBUG) && DebugLog != 0
     if (list.count != 0) {
         NSLog(@"LOADING SOFTWARE LIST: %@ \"%@\"", [dict valueForKeyPath:@"softwarelist.name"], [dict valueForKeyPath:@"softwarelist.description"]);
         for (NSDictionary* software in list)

--- a/xcode/MAME4iOS/SoftwareList.m
+++ b/xcode/MAME4iOS/SoftwareList.m
@@ -7,6 +7,7 @@
 //
 #import "SoftwareList.h"
 #import "XmlFile.h"
+#import "ZipFile.h"
 #import "GameInfo.h"
 
 #define DebugLog 0
@@ -14,9 +15,9 @@
 #define NSLog(...) (void)0
 #endif
 
-#define STR(x)  ([x isKindOfClass:[NSString class]] ? x : @"")
-#define DICT(x) ([x isKindOfClass:[NSDictionary class]] ? x : @{})
-#define LIST(x) ([x isKindOfClass:[NSArray class]]  ? x : (x ? @[x] : @[]))
+#define STR(x)      ((NSString*)([x isKindOfClass:[NSString class]]     ? x : @""))
+#define DICT(x) ((NSDictionary*)([x isKindOfClass:[NSDictionary class]] ? x : @{}))
+#define LIST(x)      ((NSArray*)([x isKindOfClass:[NSArray class]]      ? x : (x ? @[x] : @[])))
 
 #define ZIP_FILE_TYPES    @[@"zip", @"7z"]
 
@@ -156,16 +157,82 @@
     return TRUE;
 }
 
+// get the names of all files in a ZIP, excluding hidden files and directories.
+// TODO: this does not work for 7z files
+static NSArray* getZipFiles(NSString* path) {
+    NSMutableArray* files = [[NSMutableArray alloc] init];
+    [ZipFile enumerate:path withOptions:ZipFileEnumFiles usingBlock:^(ZipFileInfo* info) {
+        [files addObject:info.name];
+    }];
+    return [files copy];
+}
+
 // install a ZIP file
 - (BOOL)installZIP:(NSString*)path {
     
+    // get names of all files in this romset, if empty zip get out.
+    NSArray* files = [getZipFiles(path) valueForKeyPath:@"lastPathComponent.lowercaseString"];
+    if (files.count == 0)
+        return FALSE;
+
+    NSString* name = path.lastPathComponent.stringByDeletingPathExtension.lowercaseString;
+    NSLog(@"SEARCHING SOFTWARE LISTS FOR: %@", name);
+    NSString* found_list = nil;
+
     // figure out if this zip file is a SOFTWARE romset, buy looking for it in *all*
     // ...the installed software lists, and if it is copy it to the right subdir of `roms`
+    for (NSString* list_name in [self getSoftwareListNames]) @autoreleasepool {
+        
+        NSLog(@"    SEARCHING LIST(%@) FOR: %@", list_name, name);
+
+        NSString* path = [[hash_dir stringByAppendingPathComponent:list_name] stringByAppendingPathExtension:@"xml"];
+        NSDictionary* dict = [XmlFile dictionaryWithPath:path error:nil];
+
+        // walk all software in this list looking for a name match, then if names match check names of ROMs
+        for (NSDictionary* software in LIST([dict valueForKeyPath:@"softwarelist.software"])) {
+            
+            if (![software isKindOfClass:[NSDictionary class]])
+                continue;
+
+            // check this software if the name or the parent match
+            if ([name isEqualToString:STR(software[kSoftwareListName]).lowercaseString] || [name isEqualToString:STR(software[kSoftwareListParent]).lowercaseString]) {
+                NSLog(@"        FOUND IN %@.%@ (checking ROMs)", list_name, STR(software[kSoftwareListName]));
+
+                // now make sure the roms for this software are in this ZIP.
+                BOOL found_all_roms = TRUE;
+                for (NSDictionary* part in LIST(software[@"part"])) {
+                    for (NSDictionary* area in LIST([part valueForKeyPath:@"dataarea"])) {
+                        for (NSString* name in LIST([area valueForKeyPath:@"rom.name"])) {
+                            NSLog(@"            ROM:\"%@\" %@", name, [files containsObject:name.lowercaseString] ? @"FOUND" : @"**NOT** FOUND");
+                            if (![files containsObject:name.lowercaseString])
+                                found_all_roms = FALSE;
+                        }
+                    }
+                }
+                
+                if (found_all_roms)
+                    found_list = list_name;
+            }
+            if (found_list != nil)
+                break;
+        }
+        if (found_list != nil)
+            break;
+    }
     
-    // The smart import code in `moveROMs` is pretty good at importing software ROMs and putting
-    // them in the correct `roms` sub-folder. assuming a software list has been imported.
-    // ...so we dont need to do anything special here, maybe later to get the last 10%
+    if (found_list != nil) {
+        NSLog(@"FOUND %@ in LIST: %@", name, found_list);
+        NSString* dest_path = [[roms_dir stringByAppendingPathComponent:found_list] stringByAppendingPathComponent:path.lastPathComponent];
+        
+        // move romset to roms sub directory and overwrite any other file that is there.
+        [NSFileManager.defaultManager removeItemAtPath:dest_path error:nil];
+        [NSFileManager.defaultManager moveItemAtPath:path toPath:dest_path error:nil];
+        
+        return TRUE;
+    }
     
+    // we did not find this ZIP in any software list
+    NSLog(@"DID NOT FIND %@ in *any* SOFTWARE LIST", name);
     return FALSE;
 }
 
@@ -192,6 +259,8 @@
         if (soft_name.length == 0)
             return FALSE;
         
+        // TODO: just checkin for zip file may not be enough if the Parent and Child ROMs are merged
+        // TODO: maybe we should add all Clones if the Parent romset is present?
         NSString* soft_path = [soft_dir stringByAppendingPathComponent:soft_name];
         for (NSString* ext in ZIP_FILE_TYPES) {
             if ([NSFileManager.defaultManager fileExistsAtPath:[soft_path stringByAppendingPathExtension:ext]])

--- a/xcode/MAME4iOS/SoftwareList.m
+++ b/xcode/MAME4iOS/SoftwareList.m
@@ -149,7 +149,6 @@
         
         if (![NSFileManager.defaultManager fileExistsAtPath:clone_path]) {
             NSLog(@"....CREATING CLONE: %@", clone);
-            NSParameterAssert([clone_path.pathExtension isEqualToString:@"zip"]);
             [ZipFile exportTo:clone_path fromItems:@[] withOptions:ZipFileWriteFiles usingBlock:^ZipFileInfo* (id item) {return nil;}];
         }
     }

--- a/xcode/MAME4iOS/SoftwareList.m
+++ b/xcode/MAME4iOS/SoftwareList.m
@@ -76,9 +76,11 @@
 }
 
 // get games for a system list can be a comma separated list of softlist names
-- (NSArray<NSDictionary*>*)getGamesForSystem:(NSString*)system fromList:(NSString*)lists {
-    NSParameterAssert(![lists containsString:@" "]);
+- (NSArray<NSDictionary*>*)getGamesForSystem:(NSDictionary*)system {
+
+    NSString* lists = system.gameSoftware;
     
+    NSParameterAssert(![lists containsString:@" "]);
     if (lists.length == 0)
         return @[];
 
@@ -88,13 +90,14 @@
         for (NSDictionary* software in [self getSoftwareList:list]) {
             [games addObject:@{
                 kGameInfoSoftwareList:list,
-                kGameInfoSystem:      system,
+                kGameInfoSystem:      system.gameName,
+                kGameInfoDriver:      system.gameDriver,
                 kGameInfoName:        STR(software[kSoftwareListName]),
                 kGameInfoParent:      STR(software[kSoftwareListParent]),
                 kGameInfoDescription: STR(software[kSoftwareListDescription]),
                 kGameInfoYear:        STR(software[kSoftwareListYear]),
                 kGameInfoManufacturer:STR(software[kSoftwareListPublisher]),
-            }];
+             }];
         }
     }
 

--- a/xcode/MAME4iOS/TVOptionsController.h
+++ b/xcode/MAME4iOS/TVOptionsController.h
@@ -15,8 +15,8 @@
 
 enum OptionSections
 {
-    kInputSection = 0,
     kImportSection,
+    kInputSection,
     kScreenSection,
     kVectorSection,
     kMiscSection,

--- a/xcode/MAME4iOS/TVOptionsController.m
+++ b/xcode/MAME4iOS/TVOptionsController.m
@@ -81,6 +81,9 @@
     if ( section == kImportSection ) {
         return @"Import / Export";
     }
+    if ( section == kInputSection ) {
+        return @"Input";
+    }
 
     return @"";
 }

--- a/xcode/MAME4iOS/TVOptionsController.m
+++ b/xcode/MAME4iOS/TVOptionsController.m
@@ -156,19 +156,19 @@
         if ( indexPath.row == 0 ) {
             cell.textLabel.text = @"Filter";
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-            cell.detailTextLabel.text = [Options.arrayFilter optionName:op.filter];
+            cell.detailTextLabel.text = [Options.arrayFilter optionFind:op.filter];
         } else if ( indexPath.row == 1 ) {
             cell.textLabel.text   = @"Skin";
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-            cell.detailTextLabel.text = [Options.arraySkin optionName:op.skin];
+            cell.detailTextLabel.text = [Options.arraySkin optionFind:op.skin];
         } else if ( indexPath.row == 2 ) {
             cell.textLabel.text   = @"Screen Shader";
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-            cell.detailTextLabel.text = [Options.arrayScreenShader optionName:op.screenShader];
+            cell.detailTextLabel.text = [Options.arrayScreenShader optionFind:op.screenShader];
         } else if ( indexPath.row == 3 ) {
             cell.textLabel.text   = @"Vector Shader";
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-            cell.detailTextLabel.text = [Options.arrayLineShader optionName:op.lineShader];
+            cell.detailTextLabel.text = [Options.arrayLineShader optionFind:op.lineShader];
         } else if ( indexPath.row == 4 ) {
             cell.textLabel.text = @"Keep Aspect Ratio";
             cell.accessoryView = [self optionSwitchForKey:@"keepAspectRatio"];

--- a/xcode/MAME4iOS/ZipFile.m
+++ b/xcode/MAME4iOS/ZipFile.m
@@ -6,7 +6,7 @@
 //
 
 #import "ZipFile.h"
-#import <Compression.h>
+#import <compression.h>
 
 #if !__has_feature(objc_arc)
 #error("This file assumes ARC")


### PR DESCRIPTION
More work in progress for modern (2xx) MAME.
* Detect if the running machine takes keyboard input, and add a couple of items to the menu and HUD.
* if a machine has zero players (number of players is the number of START buttons) then don't show the menu items to automatically insert a coin and hit start, the user is on his own.
* do a Smart(er) import of a software romset, scan all the installed software lists to find the list that the romset belongs too. Note this is only done at rom import time, and only if the romset zip does not have an explicit path we recognize.
* ignore the MAME error bout failing to find language file.
* fix exit-loop when you run a naked BIOS or Console
* import merged romsets by *exploding* all the clones into empty zip files (so they show up as avail)
* import 7z archive files, as merged romsets or software
* option to show Clones in separate section