### PR TITLE
Sound Settings are back.

### DIFF
--- a/iOS/OptionsController.m
+++ b/iOS/OptionsController.m
@@ -254,6 +254,13 @@
                      cell.detailTextLabel.text = [Options.arrayEmuSpeed optionAtIndex:op.emuspeed];
                      break;
                 }
+                case 6:
+                {
+                     cell.textLabel.text   = @"Sound";
+                     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                     cell.detailTextLabel.text = [Options.arraySoundValue optionAtIndex:op.soundValue];
+                     break;
+                }
             }
             break;   
         }
@@ -417,7 +424,7 @@
           case kOtherSection: return 1;
           case kVideoSection: return 7;
           case kVectorSection: return 2;
-          case kMiscSection: return 6;
+          case kMiscSection: return 7;
           case kFilterSection: return 3;
           case kImportSection: return 3;
           case kCloudImportSection:
@@ -485,6 +492,10 @@
         {
             if (row==5) {
                 ListOptionController *listController = [[ListOptionController alloc] initWithKey:@"emuspeed" list:Options.arrayEmuSpeed title:cell.textLabel.text];
+                [[self navigationController] pushViewController:listController animated:YES];
+            }
+            if (row==6) {
+                ListOptionController *listController = [[ListOptionController alloc] initWithKey:@"soundValue" list:Options.arraySoundValue title:cell.textLabel.text];
                 [[self navigationController] pushViewController:listController animated:YES];
             }
             break;

--- a/xcode/MAME4iOS/Options.h
+++ b/xcode/MAME4iOS/Options.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (class, readonly, strong) NSArray* arrayEmuSpeed;
 @property (class, readonly, strong) NSArray* arrayControlType;
+@property (class, readonly, strong) NSArray* arraySoundValue;
 @property (class, readonly, strong) NSArray* arraySkin;
 @property (class, readonly, strong) NSArray* arrayFilter;
 @property (class, readonly, strong) NSArray* arrayScreenShader;
@@ -51,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readwrite,assign) int controltype;
 @property (readwrite,assign) int showINFO;
+
+@property (readwrite,assign) int soundValue;
 
 @property (readwrite,assign) int sticktype;
 @property (readwrite,assign) int numbuttons;

--- a/xcode/MAME4iOS/Options.m
+++ b/xcode/MAME4iOS/Options.m
@@ -21,6 +21,9 @@
 + (NSArray*)arrayControlType {
     return @[@"Keyboard",@"iCade or compatible",@"iCP, Gametel",@"iMpulse"];
 }
++ (NSArray*)arraySoundValue {
+    return @[@"Off", @"On (11 KHz)", @"On (22 KHz)",@"On (33 KHz)", @"On (44 KHz)", @"On (48 KHz)"];
+}
 
 + (NSArray*)arraySkin {
     return [SkinManager getSkinNames];
@@ -125,6 +128,8 @@
         
         _controltype = 0;
         
+        _soundValue = 5;
+
         _sticktype = 0;
         _numbuttons = 0;
         _aplusb = 0;
@@ -216,6 +221,8 @@
         _analogDeadZoneValue =  [[optionsDict objectForKey:@"analogDeadZoneValue"] intValue];
         _controltype =  [[optionsDict objectForKey:@"controlType"] intValue];
         
+        _soundValue =  [([optionsDict objectForKey:@"soundValue"] ?: @(5)) intValue];
+        
         _sticktype  =  [[optionsDict objectForKey:@"sticktype"] intValue];
         _numbuttons  =  [[optionsDict objectForKey:@"numbuttons"] intValue];
         _aplusb  =  [[optionsDict objectForKey:@"aplusb"] intValue];
@@ -289,6 +296,8 @@
                              
                              [NSString stringWithFormat:@"%d", _controltype], @"controlType",
                              
+                             [NSString stringWithFormat:@"%d", _soundValue], @"soundValue",
+
                              [NSString stringWithFormat:@"%d", _sticktype], @"sticktype",
                              [NSString stringWithFormat:@"%d", _numbuttons], @"numbuttons",
                              [NSString stringWithFormat:@"%d", _aplusb], @"aplusb",

--- a/xcode/MAME4iOS/TVOptionsController.m
+++ b/xcode/MAME4iOS/TVOptionsController.m
@@ -46,7 +46,7 @@
     } else if ( section == kVectorSection ) {
         return 2;
     } else if ( section == kMiscSection ) {
-        return 6;
+        return 7;
     } else if ( section == kInputSection ) {
         return 1;
     } else if ( section == kImportSection ) {
@@ -207,6 +207,10 @@
             cell.textLabel.text   = @"Emulated Speed";
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.detailTextLabel.text = [Options.arrayEmuSpeed optionAtIndex:op.emuspeed];
+        } else if ( indexPath.row == 6 ) {
+            cell.textLabel.text   = @"Sound";
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            cell.detailTextLabel.text = [Options.arraySoundValue optionAtIndex:op.soundValue];
         }
     } else if ( indexPath.section == kInputSection ) {
         cell.textLabel.text = @"Game Input";
@@ -265,6 +269,10 @@
     } else if ( indexPath.section == kMiscSection ) {
         if ( indexPath.row == 5 ) {
             ListOptionController *listController = [[ListOptionController alloc] initWithKey:@"emuspeed" list:Options.arrayEmuSpeed title:cell.textLabel.text];
+            [[self navigationController] pushViewController:listController animated:YES];
+        }
+        if ( indexPath.row == 6 ) {
+            ListOptionController *listController = [[ListOptionController alloc] initWithKey:@"soundValue" list:Options.arraySoundValue title:cell.textLabel.text];
             [[self navigationController] pushViewController:listController animated:YES];
         }
     } else if ( indexPath.section == kInputSection ) {


### PR DESCRIPTION
Put the Sound Settings options back, it was removed in the `OSD` purge.
different command line options are needed for 139 vs 2xx, but this handles that now.
