### PR TITLE
MAME update

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,34 +120,6 @@ Even if you are not in the paid Apple Developer Program, you can sideload the ap
 * the `hiscore` and `cheat` system has not been updated.
 * `MAME` Configure menu has a `Add To Favorites` and `Select New Machine` that dont interact with the `MAME4iOS` Ux.
 
-## **Software Lists**
-
-Software lists are containing meta-data of software for computers and consoles and are coming from various sources,
-they are not compiled in code but use as valuable source of information in order to preserve and document software.
-
-### How to add software to `MAME4iOS`
-
-* first import a *software list xml* file, you can find these files [here](https://github.com/mamedev/mame/tree/master/hash)
-    - you can also copy software list xml files *by hand* to the `hash` directory.
-* you might be tempted to just import *all* software list files, **dont** do that, it will waste diskspace on your device, and cause `MAME4iOS` to do extra work.
-* after you have imported the software list xml files, you can import `ZIP` files containing software. 
-
-If the name of the `ZIP` file *or* the subdirectory path in the `ZIP` matches the name of a software list, it will be imported directly, otherwise all software lists will be searched for a match.
-
-example zip file(s)
-```
-a2600.zip
-    pacman.zip
-    et.zip
-```
-
-```
-MySoftware.zip
-    a2600/pacman.zip
-    a2600/et.zip
-    n64/007goldnu.7z
-```
-
 ## Mixing 139 and 2xx ROMs
 Some `romsets` are not compatible between MAME 139 and newer versions, the best way to use both `romsets` at the same time is to make sure the newer ones are stored in the `7z` format and the 139 ones in the `zip` format.  This way both files can co-exist.
 

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,8 +1,10 @@
 # Version 2021.8
 * Updated to MAME 2xx core.
+* Build in all `MAME` software list `XML` files, no need to import XML files anymore.
 * Added Menu (and button in Settings) to open `Document` directory in `Files.app` (or `Finder.app`)
-* Handle romsets names that end with `dash` number.
+* Handle romsets names that end with `dash` number. (like `packman - 3.zip`)
 * Dont conflict with system keyboard shortcut for Prefrences `CMD+,`
+* Handle system keyboard shortcut for Escape `CMD+.`
 
 # Version 2021.7
 **NOTE** `MAME4iOS` 2021.7 comes in two versions, one that uses `MAME 139u1`, and one that uses the latest `MAME` (currently 234).  Make sure you download the version that is compatible with your ROMs, You can get the current version from the `Settings` page. If you want to use software based (ie cartridge, etc) romsets, please read the **Software Lists** section in the HELP or README.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,3 +1,9 @@
+# Version 2021.8
+* Updated to MAME 2xx core.
+* Added Menu (and button in Settings) to open `Document` directory in `Files.app` (or `Finder.app`)
+* Handle romsets names that end with `dash` number.
+* Dont conflict with system keyboard shortcut for Prefrences `CMD+,`
+
 # Version 2021.7
 **NOTE** `MAME4iOS` 2021.7 comes in two versions, one that uses `MAME 139u1`, and one that uses the latest `MAME` (currently 234).  Make sure you download the version that is compatible with your ROMs, You can get the current version from the `Settings` page. If you want to use software based (ie cartridge, etc) romsets, please read the **Software Lists** section in the HELP or README.
 

--- a/iOS-res/help.md
+++ b/iOS-res/help.md
@@ -200,7 +200,7 @@ below is a list of a small subset of the keys supported by MAME4iOS, for a full 
      5               | Player 1 COIN
      6               | Player 2 COIN
      TAB             | MAME UI MENU
-     ESC             | MAME UI EXIT
+     ESC or ⌘+.      | MAME UI EXIT
      RETURN          | MAME UI SELECT (aka 🅐)
 
 These keys are specific to `MAME4iOS`
@@ -382,34 +382,6 @@ Step 2\. Launch iFunBox and select your iOS device on the left hand side.
 Step 3\. click on apps icon. Now you should see a list of all of your device’s applications. Locate MAME4iOS, click it, and select Documents.
 
 Step 4\. And that’s all there is to it. Move your ROMs into this folder, launch MAME4iOS, and start playing!
-
-## Software Lists
-
-Software lists are containing meta-data of software for computers and consoles and are coming from various sources,
-they are not compiled in code but use as valuable source of information in order to preserve and document software.
-
-### How to add software to `MAME4iOS`
-
-* first import a *software list xml* file, you can find these files [here](https://github.com/mamedev/mame/tree/master/hash)
-    - you can also copy software list xml files *by hand* to the `hash` directory.
-* you might be tempted to just import *all* software list files, **dont** do that, it will waste diskspace on your device, and cause `MAME4iOS` to do extra work.
-* after you have imported the software list xml files, you can import `ZIP` files containing software. 
-
-If the name of the `ZIP` file *or* the subdirectory path in the `ZIP` matches the name of a software list, it will be imported directly, otherwise all software lists will be searched for a match.
-
-example zip file(s)
-```
-a2600.zip
-    pacman.zip
-    et.zip
-```
-
-```
-MySoftware.zip
-    a2600/pacman.zip
-    a2600/et.zip
-    n64/007goldnu.7z
-```
 
 ## Mixing 139 and 2xx ROMs
 Some `romsets` are not compatible between MAME 139 and newer versions, the best way to use both `romsets` at the same time is to make sure the newer ones are stored in the `7z` format and the 139 ones in the `zip` format.  This way both files can co-exist.

--- a/iOS/EmulatorController.h
+++ b/iOS/EmulatorController.h
@@ -65,12 +65,6 @@ enum {BTN_A,BTN_B,BTN_Y,BTN_X,BTN_L1,BTN_R1,
 #define ZIP_FILE_TYPES    @[@"zip", @"7z"]
 #define MAME_ROOT_DIRS    @[@"iOS", @"artwork", @"titles", @"cfg", @"nvram", @"ini", @"snap", @"sta", @"hi", @"inp", @"memcard", @"samples", @"roms", @"dats", @"cheat", @"skins"]
 
-@interface UINavigationController (KeyboardDismiss)
-
-- (BOOL)disablesAutomaticKeyboardDismissal;
-
-@end
-
 #if TARGET_OS_IOS
 @class AnalogStickView;
 @class LayoutView;
@@ -79,11 +73,7 @@ enum {BTN_A,BTN_B,BTN_Y,BTN_X,BTN_L1,BTN_R1,
 @class InfoHUD;
 @class KeyboardView;
 
-#if TARGET_OS_IOS
-@interface EmulatorController : UIViewController<GCDWebUploaderDelegate, UIDocumentPickerDelegate>
-#elif TARGET_OS_TV
-@interface EmulatorController : GCEventViewController<GCDWebUploaderDelegate>
-#endif
+@interface EmulatorController : GCEventViewController
 {
   @public UIView<ScreenView>* screenView;
   UIImageView	    * imageBack;

--- a/iOS/EmulatorController.h
+++ b/iOS/EmulatorController.h
@@ -152,6 +152,7 @@ enum {BTN_A,BTN_B,BTN_Y,BTN_X,BTN_L1,BTN_R1,
 - (void)runImport;
 - (void)runExport;
 - (void)runExportSkin;
+- (void)runShowFiles;
 #endif
 
 - (void)enterBackground;

--- a/iOS/EmulatorController.h
+++ b/iOS/EmulatorController.h
@@ -61,9 +61,9 @@ enum {BTN_A,BTN_B,BTN_Y,BTN_X,BTN_L1,BTN_R1,
       BTN_STICK,
       NUM_BUTTONS};
 
-#define IMPORT_FILE_TYPES @[@"zip", @"7z", @"xml"]
+#define IMPORT_FILE_TYPES @[@"zip", @"7z"]
 #define ZIP_FILE_TYPES    @[@"zip", @"7z"]
-#define MAME_ROOT_DIRS    @[@"iOS", @"artwork", @"titles", @"cfg", @"nvram", @"ini", @"snap", @"sta", @"hi", @"inp", @"memcard", @"samples", @"roms", @"dats", @"cheat", @"skins", @"hash"]
+#define MAME_ROOT_DIRS    @[@"iOS", @"artwork", @"titles", @"cfg", @"nvram", @"ini", @"snap", @"sta", @"hi", @"inp", @"memcard", @"samples", @"roms", @"dats", @"cheat", @"skins"]
 
 @interface UINavigationController (KeyboardDismiss)
 

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -853,7 +853,7 @@ void mame_save_state(int slot)
         ppc.sourceView = self.view;
 
         // use only up/down arrows if the popup can fit
-        if (ppc.permittedArrowDirections == UIPopoverArrowDirectionAny) {
+        if (viewController.preferredContentSize.height != 0 && ppc.permittedArrowDirections == UIPopoverArrowDirectionAny) {
             CGRect rect = [ppc.sourceView convertRect:ppc.sourceRect toCoordinateSpace:ppc.sourceView.window];
             CGRect safe = UIEdgeInsetsInsetRect(ppc.sourceView.window.bounds, ppc.sourceView.window.safeAreaInsets);
             CGSize size = viewController.preferredContentSize;
@@ -4355,7 +4355,7 @@ BOOL is_roms_dir(NSString* dir) {
     
     // if the ROM had a name like "foobar 1.zip", "foobar (1).zip" use only the first word as the ROM name.
     // this most likley came when a user downloaded the zip and a foobar.zip already existed, MAME ROMs are <=20 char and no spaces.
-    NSArray* words = [[romName stringByDeletingPathExtension] componentsSeparatedByString:@" "];
+    NSArray* words = [[romName stringByDeletingPathExtension] componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" -"]];
     if (words.count == 2 && [words.lastObject stringByTrimmingCharactersInSet:[NSCharacterSet punctuationCharacterSet]].intValue != 0)
         romName = [words.firstObject stringByAppendingPathExtension:romName.pathExtension];
 

--- a/iOS/EmulatorController.m
+++ b/iOS/EmulatorController.m
@@ -4818,7 +4818,21 @@ BOOL is_roms_dir(NSString* dir) {
     [top presentViewController:activity animated:YES completion:nil];
 #endif
 }
-#endif
+
+// open (aka Show in Finder or Files.app) the Document directory
+- (void)runShowFiles {
+    // first try to open Files.app, if that fails then open Finder
+    NSString* str =  [NSString stringWithFormat:@"shareddocuments://%@",  getDocumentPath(@"")];
+    NSURL* url = [[NSURL alloc] initWithString:str];
+    [UIApplication.sharedApplication openURL:url options:@{} completionHandler:^(BOOL success) {
+        if (!success) {
+            NSURL* url = [[NSURL alloc] initFileURLWithPath:getDocumentPath(@"")];
+            [UIApplication.sharedApplication openURL:url options:@{} completionHandler:nil];
+        }
+    }];
+}
+
+#endif // TARGET_OS_IOS
 
 - (void)runServer {
     [WebServer sharedInstance].webUploader.delegate = self;

--- a/iOS/KeyboardView.m
+++ b/iOS/KeyboardView.m
@@ -46,7 +46,7 @@
 #import "EmulatorController.h"
 #include "libmame.h"
 
-#define DebugLog 1
+#define DebugLog 0
 #if DebugLog == 0
 #define NSLog(...) (void)0
 #endif

--- a/iOS/KeyboardView.m
+++ b/iOS/KeyboardView.m
@@ -133,10 +133,8 @@
     
     unichar key = [text characterAtIndex:0];
     
-#if TARGET_OS_TV
     if ([emuController controllerUserInteractionEnabled])
         return;
-#endif
     
     //NSLog(@"%s: %@ (%d)", __FUNCTION__, text.debugDescription, [text characterAtIndex:0]);
 

--- a/iOS/KeyboardView.m
+++ b/iOS/KeyboardView.m
@@ -46,7 +46,7 @@
 #import "EmulatorController.h"
 #include "libmame.h"
 
-#define DebugLog 0
+#define DebugLog 1
 #if DebugLog == 0
 #define NSLog(...) (void)0
 #endif
@@ -738,6 +738,12 @@ int hid_to_mame(int keyCode) {
 //      * macOS keyboard when debugging in Xcode simulator
 //
 -(void)hardwareKey:(NSString*)key keyCode:(int)keyCode isKeyDown:(BOOL)isKeyDown modifierFlags:(UIKeyModifierFlags)modifierFlags {
+    
+#ifdef __IPHONE_13_4
+    // CMD+. will send an ESC key like this. (used on the iPad magic keyboard with no real Escape key)
+    if (key == UIKeyInputEscape)
+        keyCode = UIKeyboardHIDUsageKeyboardEscape;
+#endif
     
     NSLog(@"hardwareKey: %s%s%s%s%@ (%d) %s",
           (modifierFlags & UIKeyModifierShift)     ? "SHIFT+" : "",

--- a/iOS/OptionsController.m
+++ b/iOS/OptionsController.m
@@ -328,6 +328,13 @@
                    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
                    break;
                }
+               case 3:
+               {
+                   cell.textLabel.text = @"Show Files";
+                   cell.imageView.image = [UIImage systemImageNamed:@"folder"];
+                   cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                   break;
+               }
            }
            break;
         }
@@ -426,7 +433,7 @@
           case kVectorSection: return 2;
           case kMiscSection: return 7;
           case kFilterSection: return 3;
-          case kImportSection: return 3;
+          case kImportSection: return 4;
           case kCloudImportSection:
               if (CloudSync.status == CloudSyncStatusAvailable)
                   return 4;
@@ -510,6 +517,9 @@
             }
             if (row==2) {
                 [self.emuController runServer];
+            }
+            if (row==3) {
+                [self.emuController runShowFiles];
             }
             break;
         }

--- a/iOS/OptionsTableViewController.m
+++ b/iOS/OptionsTableViewController.m
@@ -292,4 +292,32 @@
     [sender sizeToFit];
 }
 #endif
+
+#pragma mark - ESCAPE key to dimiss
+
+#if TARGET_OS_IOS
+
+- (BOOL)canBecomeFirstResponder {
+    return YES;
+}
+
+- (void)pressesBegan:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event {
+#ifdef __IPHONE_13_4
+    if (@available(iOS 13.4, tvOS 13.4, *)) {
+        for (UIPress* press in presses) {
+            NSLog(@"KEY: %@", press.key);
+            if (press.key.keyCode == UIKeyboardHIDUsageKeyboardEscape || press.key.charactersIgnoringModifiers == UIKeyInputEscape) {
+                if (self.navigationController.viewControllers.firstObject == self)
+                    [self.emuController done:nil];
+                else
+                    [self.navigationController popViewControllerAnimated:TRUE];
+                return;
+            }
+        }
+    }
+#endif
+    [super pressesBegan:presses withEvent:event];
+}
+#endif
+
 @end

--- a/src/osd/droid-ios/libmame.h
+++ b/src/osd/droid-ios/libmame.h
@@ -46,30 +46,30 @@ enum MYOSD_AXIS {
     MYOSD_AXIS_NUM
 };
 
-#define NUM_JOY 4
-#define NUM_MICE 4
-#define NUM_GUN 4
-#define NUM_KEYS 256
+#define MYOSD_NUM_JOY 4
+#define MYOSD_NUM_MICE 4
+#define MYOSD_NUM_GUN 4
+#define MYOSD_NUM_KEYS 256
 
 // MYOSD INPUT STATE
 typedef struct {
     // keyboard
-    unsigned char keyboard[NUM_KEYS];
+    unsigned char keyboard[MYOSD_NUM_KEYS];
 
     // joystick(s)
-    unsigned long joy_status[NUM_JOY];
-    float joy_analog[NUM_JOY][MYOSD_AXIS_NUM];
+    unsigned long joy_status[MYOSD_NUM_JOY];
+    float joy_analog[MYOSD_NUM_JOY][MYOSD_AXIS_NUM];
 
     // mice
-    unsigned long mouse_status[NUM_MICE];
-    float mouse_x[NUM_JOY];
-    float mouse_y[NUM_JOY];
-    float mouse_z[NUM_JOY];
+    unsigned long mouse_status[MYOSD_NUM_MICE];
+    float mouse_x[MYOSD_NUM_MICE];
+    float mouse_y[MYOSD_NUM_MICE];
+    float mouse_z[MYOSD_NUM_MICE];
 
     // lightgun(s)
-    unsigned long lightgun_status[NUM_GUN];
-    float lightgun_x[NUM_JOY];
-    float lightgun_y[NUM_JOY];
+    unsigned long lightgun_status[MYOSD_NUM_GUN];
+    float lightgun_x[MYOSD_NUM_GUN];
+    float lightgun_y[MYOSD_NUM_GUN];
     
     // input profile for current machine
     int num_buttons;

--- a/src/osd/droid-ios/osdinput.c
+++ b/src/osd/droid-ios/osdinput.c
@@ -17,15 +17,15 @@
 #include "myosd.h"
 
 // the states
-static int joy_buttons[NUM_JOY][12];
-static int joy_axis[NUM_JOY][6];
-static int joy_hats[NUM_JOY][4];
+static int joy_buttons[MYOSD_NUM_JOY][12];
+static int joy_axis[MYOSD_NUM_JOY][6];
+static int joy_hats[MYOSD_NUM_JOY][4];
 
-static int lightgun_buttons[NUM_JOY][2];
-static int lightgun_axis[NUM_JOY][2];
+static int lightgun_buttons[MYOSD_NUM_GUN][2];
+static int lightgun_axis[MYOSD_NUM_GUN][2];
 
-static int mouse_buttons[NUM_JOY][3];   // L,R,M
-static int mouse_axis[NUM_JOY][3];      // x,y,z
+static int mouse_buttons[MYOSD_NUM_MICE][3];   // L,R,M
+static int mouse_axis[MYOSD_NUM_MICE][3];      // x,y,z
 
 static myosd_input_state myosd_input;
 
@@ -48,7 +48,7 @@ void droid_ios_init_input(running_machine *machine)
 	input_device_class_enable(machine, DEVICE_CLASS_JOYSTICK, TRUE);
 	input_device_class_enable(machine, DEVICE_CLASS_MOUSE, TRUE);
 
-	for (int i = 0; i < NUM_JOY; i++)
+	for (int i = 0; i < MYOSD_NUM_JOY; i++)
 	{
 		char name[10];
 		input_device *devinfo;
@@ -117,7 +117,7 @@ void droid_ios_init_input(running_machine *machine)
         input_device_item_add(keyboard_device, name, &myosd_input.keyboard[key], key, my_get_state);
     }
 
-    for (int i = 0; i < NUM_JOY; i++)
+    for (int i = 0; i < MYOSD_NUM_GUN; i++)
     {
         char name[10];
             snprintf(name, 10, "Lightgun %d", i + 1);
@@ -130,7 +130,10 @@ void droid_ios_init_input(running_machine *machine)
        input_device_item_add(lightgun_device, "Y Axis", &lightgun_axis[i][1], ITEM_ID_YAXIS, my_axis_get_state);
        input_device_item_add(lightgun_device, "A", &lightgun_buttons[i][0], ITEM_ID_BUTTON1, my_get_state);
        input_device_item_add(lightgun_device, "B", &lightgun_buttons[i][1], ITEM_ID_BUTTON2, my_get_state);
-
+    }
+    
+    for (int i = 0; i < MYOSD_NUM_MICE; i++)
+    {
 	   char mouse_name[10];
 	   snprintf(mouse_name, 10, "Mouse %d", i + 1);
 	   input_device *mouse_device = input_device_add(machine, DEVICE_CLASS_MOUSE, mouse_name, NULL);
@@ -294,7 +297,7 @@ void droid_ios_poll_input(running_machine *machine)
     if (myosd_input.keyboard[MYOSD_KEY_RESET] != 0 && !machine->scheduled_event_pending())
         machine->schedule_hard_reset();
     
-    for(int i=0; i<NUM_JOY; i++)
+    for(int i=0; i<MYOSD_NUM_JOY; i++)
     {
         long _pad_status = myosd_joystick_read(i);
 

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -1611,6 +1611,8 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
             // if this is a parent romset, delete all the clones too.
             if (game.gameParent.length <= 1)
                 list = [list filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"NOT (%K == %@ AND %K == %@)", kGameInfoSystem, game[kGameInfoSystem], kGameInfoParent, game.gameName]];
+            
+            // TODO: if you delete a machine/system shoud we delete all the Software too?
 
             [self setGameList:list];
 

--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -2036,6 +2036,7 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
 #pragma mark Keyboard and Game Controller navigation
 
 #if TARGET_OS_IOS
+- (void)onCommandExit  { }
 - (void)onCommandUp    { [self onCommandMove:-1 * _layoutCollums]; }
 - (void)onCommandDown  { [self onCommandMove:+1 * _layoutCollums]; }
 - (void)onCommandLeft  { [self onCommandMove:-1]; }
@@ -2119,7 +2120,7 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
 }
 - (NSArray*)keyCommands {
     
-    if (_searchController.isActive)
+    if (_searchController.isActive || self.presentedViewController != nil)
         return @[];
     
     if (_key_commands == nil) {
@@ -2130,6 +2131,7 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
             [UIKeyCommand keyCommandWithInput:UIKeyInputDownArrow   modifierFlags:0 action:@selector(onCommandDown)],
             [UIKeyCommand keyCommandWithInput:UIKeyInputLeftArrow   modifierFlags:0 action:@selector(onCommandLeft)],
             [UIKeyCommand keyCommandWithInput:UIKeyInputRightArrow  modifierFlags:0 action:@selector(onCommandRight)],
+            [UIKeyCommand keyCommandWithInput:UIKeyInputEscape      modifierFlags:0 action:@selector(onCommandExit)],
             // iCade
             [UIKeyCommand keyCommandWithInput:@"y" modifierFlags:0 action:@selector(onCommandSelect)], // SELECT
             [UIKeyCommand keyCommandWithInput:@"h" modifierFlags:0 action:@selector(onCommandSelect)], // START
@@ -2139,6 +2141,13 @@ NSAttributedString* attributedString(NSString* text, UIFont* font, UIColor* colo
             [UIKeyCommand keyCommandWithInput:@"a" modifierFlags:0 action:@selector(onCommandLeft)],
             [UIKeyCommand keyCommandWithInput:@"d" modifierFlags:0 action:@selector(onCommandRight)],
         ];
+        
+#ifdef __IPHONE_15_0
+        if (@available(iOS 15.0, *)) {
+            for (UIKeyCommand* key_command in _key_commands)
+                key_command.wantsPriorityOverSystemBehavior = YES;
+        }
+#endif
     }
     return _key_commands;
 }

--- a/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
+++ b/xcode/MAME4iOS/MAME4iOS.xcodeproj/project.pbxproj
@@ -142,6 +142,9 @@
 		EF67E11624B8972100AFF489 /* MacMenu.m in Sources */ = {isa = PBXBuildFile; fileRef = EF67E11524B8972100AFF489 /* MacMenu.m */; };
 		EF7B232C23FD0469001FF51D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		EF7B232D23FD0469001FF51D /* (null) in Sources */ = {isa = PBXBuildFile; };
+		EF7D116527348BDD00E61BB9 /* hash.zip in Resources */ = {isa = PBXBuildFile; fileRef = EF7D116427348BDD00E61BB9 /* hash.zip */; };
+		EF7D116627348BDD00E61BB9 /* hash.zip in Resources */ = {isa = PBXBuildFile; fileRef = EF7D116427348BDD00E61BB9 /* hash.zip */; };
+		EF7D116727348BDD00E61BB9 /* hash.zip in Resources */ = {isa = PBXBuildFile; fileRef = EF7D116427348BDD00E61BB9 /* hash.zip */; };
 		EF8409A2260CEFAB00FAC3CF /* AVPlayerView.m in Sources */ = {isa = PBXBuildFile; fileRef = EF8409A1260CEFAB00FAC3CF /* AVPlayerView.m */; };
 		EF8409A3260CEFAB00FAC3CF /* AVPlayerView.m in Sources */ = {isa = PBXBuildFile; fileRef = EF8409A1260CEFAB00FAC3CF /* AVPlayerView.m */; };
 		EF8409A9260CF3F200FAC3CF /* whiteHDR.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = EF8409A8260CF3F200FAC3CF /* whiteHDR.mp4 */; };
@@ -529,6 +532,7 @@
 		EF55DE312533C21E004E37EF /* MAME4iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MAME4iOS.xcconfig; sourceTree = "<group>"; };
 		EF55DE5A2534C304004E37EF /* TVServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TVServices.framework; path = Library/Frameworks/TVServices.framework; sourceTree = DEVELOPER_DIR; };
 		EF67E11524B8972100AFF489 /* MacMenu.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MacMenu.m; sourceTree = "<group>"; };
+		EF7D116427348BDD00E61BB9 /* hash.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; name = hash.zip; path = "../../iOS-res/hash.zip"; sourceTree = "<group>"; };
 		EF8409A0260CEFAB00FAC3CF /* AVPlayerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVPlayerView.h; sourceTree = "<group>"; };
 		EF8409A1260CEFAB00FAC3CF /* AVPlayerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVPlayerView.m; sourceTree = "<group>"; };
 		EF8409A8260CF3F200FAC3CF /* whiteHDR.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; name = whiteHDR.mp4; path = "../../iOS-res/whiteHDR.mp4"; sourceTree = "<group>"; };
@@ -962,6 +966,7 @@
 		EF1C941624C2544A00749C69 /* content */ = {
 			isa = PBXGroup;
 			children = (
+				EF7D116427348BDD00E61BB9 /* hash.zip */,
 				EF1C93ED24C252C500749C69 /* history0139.zip */,
 				EF1C93EB24C252C500749C69 /* hiscore.dat */,
 				EF1C93E824C252C500749C69 /* Category.ini */,
@@ -1229,6 +1234,7 @@
 			files = (
 				EF1C940C24C252C600749C69 /* hiscore.dat in Resources */,
 				EF26AE08241848800078FD30 /* mame_logo.png in Resources */,
+				EF7D116527348BDD00E61BB9 /* hash.zip in Resources */,
 				EF1C93FD24C252C600749C69 /* skins in Resources */,
 				EF1C93F724C252C600749C69 /* LICENSE in Resources */,
 				EFA7570524057FD800A02AAB /* default_game_icon.png in Resources */,
@@ -1267,6 +1273,7 @@
 				92A533D121EBDDF20089FBB9 /* GCDWebUploader.bundle in Resources */,
 				EF1C941D24C2552900749C69 /* gitinfo.json.sh in Resources */,
 				EFFBA6FF24F1C91200F8666B /* WHATSNEW.md in Resources */,
+				EF7D116627348BDD00E61BB9 /* hash.zip in Resources */,
 				EF1C941324C252C600749C69 /* history0139.zip in Resources */,
 				B5FAE31921FCE64D003F44D0 /* MAME_tvOS.lsr in Resources */,
 			);
@@ -1285,6 +1292,7 @@
 				EF1C941E24C2552900749C69 /* gitinfo.json.sh in Resources */,
 				EF1C941424C252C600749C69 /* history0139.zip in Resources */,
 				EFA7A16D24B7A40F0009CF88 /* Assets.xcassets in Resources */,
+				EF7D116727348BDD00E61BB9 /* hash.zip in Resources */,
 				EFA7A14324B65C020009CF88 /* dpad.png in Resources */,
 				EFA7A14424B65C020009CF88 /* Launch Screen.storyboard in Resources */,
 				EFFBA70024F1C91200F8666B /* WHATSNEW.md in Resources */,

--- a/xcode/MAME4iOS/MAME4iOS/MAME4iOS-Info.plist
+++ b/xcode/MAME4iOS/MAME4iOS/MAME4iOS-Info.plist
@@ -52,28 +52,6 @@
                 <string>org.7-zip.7-zip-archive</string>
             </array>
         </dict>
-        <dict>
-            <key>CFBundleTypeExtensions</key>
-            <array>
-                <string>xml</string>
-                <string>XML</string>
-            </array>
-            <key>CFBundleTypeMIMETypes</key>
-            <array>
-                <string>application/xml</string>
-                <string>text/xml</string>
-            </array>
-            <key>CFBundleTypeName</key>
-            <string>XML text</string>
-            <key>CFBundleTypeRole</key>
-            <string>Viewer</string>
-            <key>LSHandlerRank</key>
-            <string>Alternate</string>
-            <key>LSItemContentTypes</key>
-            <array>
-                <string>public.xml</string>
-            </array>
-        </dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>

--- a/xcode/MAME4iOS/MAME4mac/MAME4mac-Info.plist
+++ b/xcode/MAME4iOS/MAME4mac/MAME4mac-Info.plist
@@ -52,28 +52,6 @@
                 <string>org.7-zip.7-zip-archive</string>
             </array>
         </dict>
-        <dict>
-            <key>CFBundleTypeExtensions</key>
-            <array>
-                <string>xml</string>
-                <string>XML</string>
-            </array>
-            <key>CFBundleTypeMIMETypes</key>
-            <array>
-                <string>application/xml</string>
-                <string>text/xml</string>
-            </array>
-            <key>CFBundleTypeName</key>
-            <string>XML text</string>
-            <key>CFBundleTypeRole</key>
-            <string>Viewer</string>
-            <key>LSHandlerRank</key>
-            <string>Alternate</string>
-            <key>LSItemContentTypes</key>
-            <array>
-                <string>public.xml</string>
-            </array>
-        </dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>

--- a/xcode/MAME4iOS/MacMenu.m
+++ b/xcode/MAME4iOS/MacMenu.m
@@ -69,6 +69,7 @@
         [UICommand commandWithTitle:@"Export..."     image:[UIImage systemImageNamed:@"square.and.arrow.up.on.square"]        action:@selector(fileExport) propertyList:nil],
 //      [UICommand commandWithTitle:@"Export Skin..."image:[UIImage systemImageNamed:@"square.and.arrow.up"]        action:@selector(fileExportSkin) propertyList:nil],
         [UICommand commandWithTitle:@"Start Server"  image:[UIImage systemImageNamed:@"arrow.up.arrow.down.circle"] action:@selector(fileStartServer) propertyList:nil],
+        [UICommand commandWithTitle:@"Show Files"    image:[UIImage systemImageNamed:@"folder"] action:@selector(fileShowFiles) propertyList:nil],
     ]] atStartOfMenuForIdentifier:UIMenuFile];
     
     // UIKeyInputF3 is only valid on 13.4 or later, avoid a build warning
@@ -117,6 +118,9 @@
 }
 -(void)fileExportSkin {
     [hrViewController runExportSkin];
+}
+-(void)fileShowFiles {
+    [hrViewController runShowFiles];
 }
 
 @end

--- a/xcode/MAME4iOS/MacMenu.m
+++ b/xcode/MAME4iOS/MacMenu.m
@@ -87,7 +87,7 @@
         [UIKeyCommand commandWithTitle:@"Coin+Start"image:[UIImage systemImageNamed:@"person.circle"]       action:@selector(mameStartP1)   input:@"1" modifierFlags:UIKeyModifierCommand propertyList:nil],
         [UIKeyCommand commandWithTitle:@"Fullscreen"image:[UIImage systemImageNamed:@"rectangle.and.arrow.up.right.and.arrow.down.left"]
                                 action:@selector(mameFullscreen) input:@"\r" modifierFlags:UIKeyModifierCommand propertyList:nil],
-        [UIKeyCommand commandWithTitle:@"Settings"  image:[UIImage systemImageNamed:@"gear"]                action:@selector(mameSettings)  input:@"," modifierFlags:UIKeyModifierCommand propertyList:nil],
+        [UIKeyCommand commandWithTitle:@"Settings"  image:[UIImage systemImageNamed:@"gear"]                action:@selector(mameSettings)  input:@"." modifierFlags:UIKeyModifierCommand propertyList:nil],
         [UIKeyCommand commandWithTitle:@"Configure" image:[UIImage systemImageNamed:@"slider.horizontal.3"] action:@selector(mameConfigure) input:@"\t" modifierFlags:0 propertyList:nil],
         [UIKeyCommand commandWithTitle:@"Pause"     image:[UIImage systemImageNamed:@"pause.circle"]        action:@selector(mamePause)     input:@"P" modifierFlags:0 propertyList:nil],
         [UIKeyCommand commandWithTitle:@"Reset"     image:[UIImage systemImageNamed:@"power"]               action:@selector(mameReset)     input:keyF3 modifierFlags:0 propertyList:nil],

--- a/xcode/MAME4iOS/MacMenu.m
+++ b/xcode/MAME4iOS/MacMenu.m
@@ -88,7 +88,7 @@
         [UIKeyCommand commandWithTitle:@"Coin+Start"image:[UIImage systemImageNamed:@"person.circle"]       action:@selector(mameStartP1)   input:@"1" modifierFlags:UIKeyModifierCommand propertyList:nil],
         [UIKeyCommand commandWithTitle:@"Fullscreen"image:[UIImage systemImageNamed:@"rectangle.and.arrow.up.right.and.arrow.down.left"]
                                 action:@selector(mameFullscreen) input:@"\r" modifierFlags:UIKeyModifierCommand propertyList:nil],
-        [UIKeyCommand commandWithTitle:@"Settings"  image:[UIImage systemImageNamed:@"gear"]                action:@selector(mameSettings)  input:@"." modifierFlags:UIKeyModifierCommand propertyList:nil],
+        [UIKeyCommand commandWithTitle:@"Settings"  image:[UIImage systemImageNamed:@"gear"]                action:@selector(mameSettings)  input:@"/" modifierFlags:UIKeyModifierCommand propertyList:nil],
         [UIKeyCommand commandWithTitle:@"Configure" image:[UIImage systemImageNamed:@"slider.horizontal.3"] action:@selector(mameConfigure) input:@"\t" modifierFlags:0 propertyList:nil],
         [UIKeyCommand commandWithTitle:@"Pause"     image:[UIImage systemImageNamed:@"pause.circle"]        action:@selector(mamePause)     input:@"P" modifierFlags:0 propertyList:nil],
         [UIKeyCommand commandWithTitle:@"Reset"     image:[UIImage systemImageNamed:@"power"]               action:@selector(mameReset)     input:keyF3 modifierFlags:0 propertyList:nil],

--- a/xcode/MAME4iOS/SoftwareList.h
+++ b/xcode/MAME4iOS/SoftwareList.h
@@ -21,6 +21,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithPath:(NSString*)root;
 
+// get names of all software lists
+- (NSArray<NSString*>*)getSoftwareListNames;
+
 // get software list by name, filtered to only Available
 - (NSArray<NSDictionary*>*)getSoftwareList:(NSString*)name;
 
@@ -28,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<NSDictionary*>*)getGamesForSystem:(NSDictionary*)system;
 
 // get name of software list for a romset, used to know where to install.
-- (nullable NSString*)getSoftwareListForPath:(NSString*)path andName:(NSString*)name;
+- (nullable NSString*)getSoftwareListNameForRomset:(NSString*)path named:(NSString*)name;
 
 // if this a merged romset, extract clones as empty zip files so they show up as Available
 - (BOOL)extractClones:(NSString*)path;

--- a/xcode/MAME4iOS/SoftwareList.h
+++ b/xcode/MAME4iOS/SoftwareList.h
@@ -21,26 +21,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithPath:(NSString*)root;
 
-// get software list names
-- (NSArray<NSString*>*)getSoftwareListNames;
-
-// get software list
+// get software list by name, filtered to only Available
 - (NSArray<NSDictionary*>*)getSoftwareList:(NSString*)name;
 
-// get games for a system
+// get games for a system, filtered to only Available
 - (NSArray<NSDictionary*>*)getGamesForSystem:(NSDictionary*)system;
 
-// install a XML or ZIP file
-- (BOOL)installFile:(NSString*)path;
+// get name of software list for a romset, used to know where to install.
+- (nullable NSString*)getSoftwareListForPath:(NSString*)path andName:(NSString*)name;
 
 // if this a merged romset, extract clones as empty zip files so they show up as Available
 - (BOOL)extractClones:(NSString*)path;
 
 // discard any cached data, forcing a re-load from disk.
 - (void)reload;
-
-// delete all software lists
-- (void)reset;
 
 @end
 

--- a/xcode/MAME4iOS/SoftwareList.m
+++ b/xcode/MAME4iOS/SoftwareList.m
@@ -234,7 +234,7 @@ static NSArray<NSString*>* getZipFiles(NSString* path) {
     
     // if the ROM had a name like "foobar 1.zip", "foobar (1).zip" use only the first word as the ROM name.
     // this most likley came when a user downloaded the zip and a foobar.zip already existed, MAME ROMs are <=20 char and no spaces.
-    NSArray* words = [name componentsSeparatedByString:@" "];
+    NSArray* words = [name componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" -"]];
     if (words.count == 2 && [words.lastObject stringByTrimmingCharactersInSet:[NSCharacterSet punctuationCharacterSet]].intValue != 0)
         name = words.firstObject;
     

--- a/xcode/MAME4iOS/SoftwareList.m
+++ b/xcode/MAME4iOS/SoftwareList.m
@@ -9,15 +9,17 @@
 #import "XmlFile.h"
 #import "ZipFile.h"
 #import "GameInfo.h"
+#import <CommonCrypto/CommonDigest.h>
 
 #define DebugLog 0
 #if DebugLog == 0 || !defined(DEBUG)
 #define NSLog(...) (void)0
 #endif
 
-#define STR(x)      ((NSString*)([x isKindOfClass:[NSString class]]     ? x : @""))
-#define DICT(x) ((NSDictionary*)([x isKindOfClass:[NSDictionary class]] ? x : @{}))
-#define LIST(x)      ((NSArray*)([x isKindOfClass:[NSArray class]]      ? x : (x ? @[x] : @[])))
+// SAFE access to values in XML files
+#define STR(x)  ({id s = x; [s isKindOfClass:[NSString class]] ? (NSString*)(s) : @"";})
+#define DICT(x) ({id d = x; [d isKindOfClass:[NSDictionary class]] ? (NSDictionary*)(d) : @{};})
+#define LIST(x) ({id a = x; [a isKindOfClass:[NSArray class]] ? (NSArray*)(a) : (a ? @[a] : @[]);})
 
 #define ZIP_FILE_TYPES    @[@"zip", @"7z"]
 
@@ -27,7 +29,7 @@
 
 @implementation SoftwareList
 {
-    NSString* hash_dir;
+    NSString* hash_zip;
     NSString* roms_dir;
     NSCache*  software_list_cache;
 }
@@ -37,28 +39,13 @@
 - (instancetype)initWithPath:(NSString*)root
 {
     self = [super init];
-    hash_dir = [root stringByAppendingPathComponent:@"hash"];
+    hash_zip = [root stringByAppendingPathComponent:@"hash.zip"];
     roms_dir = [root stringByAppendingPathComponent:@"roms"];
     software_list_cache = [[NSCache alloc] init];
     return self;
 }
 
 #pragma mark Public methods
-
-// get software list names
-- (NSArray*)getSoftwareListNames {
-    @synchronized (self) {
-        NSArray* list = [software_list_cache objectForKey:@"*"];
-        if (list == nil) {
-            @autoreleasepool {
-                list = [NSFileManager.defaultManager contentsOfDirectoryAtPath:hash_dir error:nil];
-                list = [list valueForKey:@"stringByDeletingPathExtension"];
-                [software_list_cache setObject:list forKey:@"*"];
-            }
-        }
-        return list;
-    }
-}
 
 // get software list, from cache, or load and validate the ROMs
 - (NSArray*)getSoftwareList:(NSString*)name {
@@ -75,10 +62,10 @@
     }
 }
 
-// get games for a system list can be a comma separated list of softlist names
+// get games for a system
 - (NSArray<NSDictionary*>*)getGamesForSystem:(NSDictionary*)system {
 
-    NSString* lists = system.gameSoftware;
+    NSString* lists = system.gameSoftware; // this can be a comma separated list of softlist names
     
     NSParameterAssert(![lists containsString:@" "]);
     if (lists.length == 0)
@@ -104,18 +91,88 @@
     return games;
 }
 
-// install a XML or ZIP file
-- (BOOL)installFile:(NSString*)path {
- 
-    @autoreleasepool {
-        if ([ZIP_FILE_TYPES containsObject:path.pathExtension.lowercaseString])
-            return [self installZIP:path];
+// get name of software list for a romset, this is used at install time.
+//
+// this is to solve the "pacman problem", there is a pacman.zip for almost every system
+// given a zip file we need to find out what software list directory to copy it to, and this
+// involves searching *all* the software list XMLs looking for a match. we do some cacheing/etc
+// to make this not terribly slow, but we still need to search
+//
+// we use a cached pre-computed database to find the possible software list names to search
+//
+- (nullable NSString*)getSoftwareListForPath:(NSString*)path andName:(NSString*)name {
+    
+    if (name.length == 0)
+        name = path.lastPathComponent.stringByDeletingPathExtension.lowercaseString;
 
-        if ([@[@"xml"] containsObject:path.pathExtension.lowercaseString])
-            return [self installXML:path];
+    // get SHA1 of all files in this romset
+    NSArray* hashes = getZipFileSHA1(path);
+    if (hashes.count == 0)
+        return FALSE;
+
+    // get subset of software lists to search
+    NSDictionary* soft_list_db = [self getSoftwareListDatabase];
+    NSArray* list_names = LIST(soft_list_db[name]);
+    
+    NSLog(@"SEARCHING SOFTWARE LISTS(%@) FOR: %@", [list_names componentsJoinedByString:@", "], name);
+
+    // figure out if this zip file is a SOFTWARE romset, by looking for it in *all* the installed software lists
+    for (NSString* list_name in list_names) @autoreleasepool {
+        
+        NSLog(@"    SEARCHING LIST(%@) FOR: %@", list_name, name);
+
+        NSDictionary* dict = [self getSoftwareListXML:list_name];
+
+        // walk all software in this list looking for a name match, then if names match check ROMs and DISKs
+        for (NSDictionary* software in LIST([dict valueForKeyPath:@"softwarelist.software"])) {
+            
+            if (![software isKindOfClass:[NSDictionary class]])
+                continue;
+
+            // check this software if the name matches
+            if ([name isEqualToString:STR(software[kSoftwareListName]).lowercaseString]) {
+                NSLog(@"        FOUND IN %@.%@ (checking ROMs)", list_name, STR(software[kSoftwareListName]));
+
+                // now make sure all the roms (and disks) for this software are in this ZIP.
+                int rom_count = 0;
+                int zip_count = 0;
+                for (NSDictionary* part in LIST(software[@"part"])) {
+                    
+                    // look at all the ROMs and see if they are in the ZIP
+                    for (NSDictionary* area in LIST([part valueForKeyPath:@"dataarea"])) {
+                        for (NSString* hash in LIST([area valueForKeyPath:@"rom.sha1"])) {
+                            if (![hash isKindOfClass:[NSString class]] || hash.length == 0)
+                                continue;
+                            NSLog(@"            ROM:%@ %@", hash, [hashes containsObject:hash.lowercaseString] ? @"FOUND" : @"**NOT** FOUND");
+                            rom_count++;
+                            if ([hashes containsObject:hash.lowercaseString])
+                                zip_count++;
+                        }
+                    }
+                    
+                    // look at all the DISKs and see if they are in the ZIP
+                    for (NSDictionary* area in LIST([part valueForKeyPath:@"diskarea"])) {
+                        for (NSString* hash in LIST([area valueForKeyPath:@"disk.sha1"])) {
+                            if (![hash isKindOfClass:[NSString class]] || hash.length == 0)
+                                continue;
+                            NSLog(@"           DISK:%@ %@", hash, [hashes containsObject:hash.lowercaseString] ? @"FOUND" : @"**NOT** FOUND");
+                            rom_count++;
+                            if ([hashes containsObject:hash.lowercaseString])
+                                zip_count++;
+                        }
+                    }
+                }
+                
+                if (rom_count != 0 && rom_count == zip_count) {
+                    NSLog(@"FOUND %@ in LIST: %@", name, list_name);
+                    return list_name;
+                }
+            }
+        }
     }
-
-    return FALSE;
+    
+    NSLog(@"DID NOT FIND %@ in *any* SOFTWARE LIST", name);
+    return nil;
 }
 
 // if this a merged romset, extract clones as empty zip files so they show up as Available
@@ -133,7 +190,7 @@
     NSLog(@"EXTRACT CLONES: %@", path);
     
     // get directory names of all files in this romset
-    NSSet* clones = [NSSet setWithArray:[getZipFiles(path) valueForKeyPath:@"stringByDeletingLastPathComponent.lowercaseString"]];
+    NSSet* clones = [NSSet setWithArray:[getZipFileNames(path) valueForKeyPath:@"stringByDeletingLastPathComponent.lowercaseString"]];
     
     if (clones.count < 2 || ![clones containsObject:@""]) {
         NSLog(@"....NOT A MERGED ROMSET");
@@ -162,54 +219,10 @@
     }
 }
 
-// delete all software
-- (void)reset {
-    for (NSString* name in [self getSoftwareListNames])  {
-        NSString* roms_path = [roms_dir stringByAppendingPathComponent:name];
-        [NSFileManager.defaultManager removeItemAtPath:roms_path error:nil];
-        NSString* titles_path = [roms_dir stringByAppendingPathComponent:[NSString stringWithFormat:@"../titles/%@", name]];
-        [NSFileManager.defaultManager removeItemAtPath:titles_path error:nil];
-    }
-    [NSFileManager.defaultManager removeItemAtPath:hash_dir error:nil];
-    [NSFileManager.defaultManager createDirectoryAtPath:hash_dir withIntermediateDirectories:NO attributes:nil error:nil];
-    [self reload];
-}
-
 #pragma mark Private methods
 
-// install a XML file
-- (BOOL)installXML:(NSString*)path {
-    
-    // load the XML file
-    NSDictionary* dict = [XmlFile dictionaryWithPath:path error:nil];
-
-    NSString* name = STR([dict valueForKeyPath:@"softwarelist.name"]);
-    NSString* desc = STR([dict valueForKeyPath:@"softwarelist.description"]);
-    NSArray*  list = LIST([dict valueForKeyPath:@"softwarelist.software"]);
-
-    if (name.length == 0 || desc.length == 0 || list.count == 0) {
-        NSLog(@"INVALID SOFTWARE LIST: %@", path);
-        return FALSE;
-    }
-    
-    NSLog(@"INSTALL SOFTWARE LIST: %@ \"%@\" (%d items)", name, desc, (int)list.count);
-    
-    NSString* hash_path = [[hash_dir stringByAppendingPathComponent:name] stringByAppendingPathExtension:@"xml"];
-    NSString* roms_path = [roms_dir stringByAppendingPathComponent:name];
-
-    // move software list xml to the `hash` directory (overwrite file)
-    [NSFileManager.defaultManager removeItemAtPath:hash_path error:nil];
-    [NSFileManager.defaultManager moveItemAtPath:path toPath:hash_path error:nil];
-    
-    // create (if needed) directory to hold software ROMs
-    [NSFileManager.defaultManager createDirectoryAtPath:roms_path withIntermediateDirectories:NO attributes:nil error:nil];
-    
-    return TRUE;
-}
-
 // get the names of all files in a ZIP, excluding hidden files and directories.
-// TODO: this does not work for 7z files
-static NSArray<NSString*>* getZipFiles(NSString* path) {
+static NSArray<NSString*>* getZipFileNames(NSString* path) {
     NSMutableArray* files = [[NSMutableArray alloc] init];
     [ZipFile enumerate:path withOptions:ZipFileEnumFiles usingBlock:^(ZipFileInfo* info) {
         [files addObject:info.name];
@@ -217,102 +230,81 @@ static NSArray<NSString*>* getZipFiles(NSString* path) {
     return [files copy];
 }
 
-// install a ZIP file
-- (BOOL)installZIP:(NSString*)path {
+static NSString* sha1(NSData* data) {
+    if (data.length == 0)
+        return @"";
+    uint8_t digest[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1(data.bytes, (CC_LONG)data.length, digest);
 
-    // if we dont have any software lists, bail
-    NSArray* list_names = [self getSoftwareListNames];
-    if (list_names.count == 0)
-        return FALSE;
-    
-    // get names of all files in this romset, if empty zip get out.
-    NSArray* files = [getZipFiles(path) valueForKeyPath:@"lastPathComponent.lowercaseString"];
-    if (files.count == 0)
-        return FALSE;
-
-    NSString* name = path.lastPathComponent.stringByDeletingPathExtension.lowercaseString;
-    
-    // if the ROM had a name like "foobar 1.zip", "foobar (1).zip" use only the first word as the ROM name.
-    // this most likley came when a user downloaded the zip and a foobar.zip already existed, MAME ROMs are <=20 char and no spaces.
-    NSArray* words = [name componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" -"]];
-    if (words.count == 2 && [words.lastObject stringByTrimmingCharactersInSet:[NSCharacterSet punctuationCharacterSet]].intValue != 0)
-        name = words.firstObject;
-    
-    NSLog(@"SEARCHING SOFTWARE LISTS FOR: %@", name);
-
-    // figure out if this zip file is a SOFTWARE romset, buy looking for it in *all*
-    // ...the installed software lists, and if it is copy it to the right subdir of `roms`
-    for (NSString* list_name in list_names) @autoreleasepool {
-        
-        NSLog(@"    SEARCHING LIST(%@) FOR: %@", list_name, name);
-
-        NSDictionary* dict = [self loadSoftwareListXML:list_name cache:YES];
-
-        // walk all software in this list looking for a name match, then if names match check names of ROMs
-        for (NSDictionary* software in LIST([dict valueForKeyPath:@"softwarelist.software"])) {
-            
-            if (![software isKindOfClass:[NSDictionary class]])
-                continue;
-
-            // check this software if the name or the parent match
-            if ([name isEqualToString:STR(software[kSoftwareListName]).lowercaseString] || [name isEqualToString:STR(software[kSoftwareListParent]).lowercaseString]) {
-                NSLog(@"        FOUND IN %@.%@ (checking ROMs)", list_name, STR(software[kSoftwareListName]));
-
-                // now make sure the roms for this software are in this ZIP.
-                BOOL found_all_roms = TRUE;
-                for (NSDictionary* part in LIST(software[@"part"])) {
-                    for (NSDictionary* area in LIST([part valueForKeyPath:@"dataarea"])) {
-                        for (NSString* name in LIST([area valueForKeyPath:@"rom.name"])) {
-                            NSLog(@"            ROM:\"%@\" %@", name, [files containsObject:name.lowercaseString] ? @"FOUND" : @"**NOT** FOUND");
-                            if (![files containsObject:name.lowercaseString])
-                                found_all_roms = FALSE;
-                        }
-                    }
-                }
-                
-                if (found_all_roms) {
-                    NSLog(@"FOUND %@ in LIST: %@", name, list_name);
-                    NSString* dest_path = [[[roms_dir stringByAppendingPathComponent:list_name] stringByAppendingPathComponent:name] stringByAppendingPathExtension:path.pathExtension];
-                    
-                    // move romset to roms sub directory and overwrite any other file that is there.
-                    [NSFileManager.defaultManager removeItemAtPath:dest_path error:nil];
-                    [NSFileManager.defaultManager moveItemAtPath:path toPath:dest_path error:nil];
-                    
-                    [self extractClones:dest_path];
-                    return TRUE;
-                }
-            }
-        }
-    }
-    
-    NSLog(@"DID NOT FIND %@ in *any* SOFTWARE LIST", name);
-    return FALSE;
+    return [NSString stringWithFormat: @"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+            digest[0], digest[1], digest[2], digest[3],
+            digest[4], digest[5], digest[6], digest[7],
+            digest[8], digest[9], digest[10], digest[11],
+            digest[12],digest[13], digest[14], digest[15],
+            digest[16],digest[17], digest[18], digest[19]];
 }
 
-// load software list xml file (and maybe cache it)
-- (NSDictionary*)loadSoftwareListXML:(NSString*)name cache:(BOOL)cache {
+// get the SHA1 of all files in a ZIP, excluding hidden files and directories.
+static NSArray<NSString*>* getZipFileSHA1(NSString* path) {
+    NSMutableArray* hashes = [[NSMutableArray alloc] init];
+    [ZipFile enumerate:path withOptions:ZipFileEnumFiles usingBlock:^(ZipFileInfo* info) {
+        [hashes addObject:sha1(info.data)];
+    }];
+    return [hashes copy];
+}
+
+// load software list xml file, but check cache first
+- (NSDictionary*)getSoftwareListXML:(NSString*)name {
     NSParameterAssert(name.length != 0);
-    NSString* path = [[hash_dir stringByAppendingPathComponent:name] stringByAppendingPathExtension:@"xml"];
+    NSString* key = [name stringByAppendingPathExtension:@"xml"];   // use swlist.xml as key to not conflict with getSoftwareList
     
     @synchronized (self) {
-        NSDictionary* dict = [software_list_cache objectForKey:path];
+        NSDictionary* dict = [software_list_cache objectForKey:key];
         if (dict == nil) {
             @autoreleasepool {
-                dict = [XmlFile dictionaryWithPath:path error:nil];
-                if (cache)
-                    [software_list_cache setObject:dict forKey:path];
+                dict = [self loadSoftwareListXML:name];
+                [software_list_cache setObject:dict forKey:key];
             }
         }
         return dict;
     }
 }
 
-// load software list, and validate the ROMs
+// load software list xml file
+// NOTE all the software lists are inside `hash.zip` (not as separate files)
+- (NSDictionary*)loadSoftwareListXML:(NSString*)name {
+    
+    __block NSDictionary* dict = nil;
+    [ZipFile enumerate:hash_zip withOptions:ZipFileEnumFiles usingBlock:^(ZipFileInfo* info) {
+        
+        if (dict != nil)
+            return;
+        
+        if (![info.name.pathExtension.lowercaseString isEqualToString:@"xml"])
+            return;
+        
+        if (![info.name.lastPathComponent.stringByDeletingPathExtension.lowercaseString isEqualToString:name.lowercaseString])
+            return;
+
+        if (info.data == nil)
+            return;
+        
+        dict = [XmlFile dictionaryWithData:info.data error:nil];
+    }];
+
+    return dict;
+}
+
+// load software list, and validate the ROMs (ie filter software list down to only Available software)
 - (NSArray*)loadSoftwareList:(NSString*)list_name {
     NSParameterAssert(list_name.length != 0);
     
-    // load the XML file
-    NSDictionary* dict = [self loadSoftwareListXML:list_name cache:FALSE];
+#if defined(DEBUG) && DebugLog != 0
+    NSTimeInterval time = [NSDate timeIntervalSinceReferenceDate];
+#endif
+
+    // load the XML file, NOTE we dont need to use cached XML because our result gets cached.
+    NSDictionary* dict = [self loadSoftwareListXML:list_name];
     
     // get all the software in the list
     NSArray* list = LIST([dict valueForKeyPath:@"softwarelist.software"]);
@@ -328,8 +320,6 @@ static NSArray<NSString*>* getZipFiles(NSString* path) {
         if (soft_name.length == 0)
             return FALSE;
         
-        // TODO: just checkin for zip file may not be enough if the Parent and Child ROMs are merged
-        // TODO: maybe we should add all Clones if the Parent romset is present?
         NSString* soft_path = [soft_dir stringByAppendingPathComponent:soft_name];
         for (NSString* ext in ZIP_FILE_TYPES) {
             if ([NSFileManager.defaultManager fileExistsAtPath:[soft_path stringByAppendingPathExtension:ext]])
@@ -338,17 +328,90 @@ static NSArray<NSString*>* getZipFiles(NSString* path) {
 
         return FALSE;
     }]];
-
+    
 #if defined(DEBUG) && DebugLog != 0
-    if (list.count != 0) {
-        NSLog(@"LOADING SOFTWARE LIST: %@ \"%@\"", [dict valueForKeyPath:@"softwarelist.name"], [dict valueForKeyPath:@"softwarelist.description"]);
-        for (NSDictionary* software in list)
-            NSLog(@"    %@, %@, %@, \"%@\"", software[kSoftwareListName], software[kSoftwareListYear], software[kSoftwareListPublisher], software[kSoftwareListDescription]);
-    }
+    NSLog(@"LOADING SOFTWARE LIST: %@ \"%@\" %d items, %0.3fsec", [dict valueForKeyPath:@"softwarelist.name"], [dict valueForKeyPath:@"softwarelist.description"], (int)list.count, [NSDate timeIntervalSinceReferenceDate] - time);
+    for (NSDictionary* software in list)
+        NSLog(@"    %@, %@, %@, \"%@\"", software[kSoftwareListName], software[kSoftwareListYear], software[kSoftwareListPublisher], software[kSoftwareListDescription]);
 #endif
     
     return list;
 }
 
+// get database that maps romset name to possible software lists
+- (NSDictionary*)getSoftwareListDatabase {
+    NSString* key = @"hash.dat";
+    
+    @synchronized (self) {
+        NSDictionary* dict = [software_list_cache objectForKey:key];
+        if (dict == nil) {
+            @autoreleasepool {
+                dict = [self loadSoftwareListDatabase];
+                [software_list_cache setObject:dict forKey:key];
+            }
+        }
+        return dict;
+    }
+}
+
+// load/create software list database
+- (NSDictionary*)loadSoftwareListDatabase {
+    
+    NSString* hash_dat = [hash_zip.stringByDeletingPathExtension stringByAppendingPathExtension:@"dat"];
+    
+    NSDate* zip_date = [[NSFileManager.defaultManager attributesOfItemAtPath:hash_zip error:nil] fileModificationDate];
+    NSDate* dat_date = [[NSFileManager.defaultManager attributesOfItemAtPath:hash_dat error:nil] fileModificationDate] ?: NSDate.distantPast;
+    
+    // load `HASH.DAT` if it is not older than `HASH.ZIP` otherwise build it.
+    if ([zip_date compare:dat_date] != NSOrderedDescending) {
+        NSData* data = [NSData dataWithContentsOfFile:hash_dat] ?: [[NSData alloc] init];
+        NSDictionary* dict = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable format:nil error:nil];
+        NSParameterAssert([dict isKindOfClass:[NSDictionary class]]);
+
+        if ([dict isKindOfClass:[NSDictionary class]])
+            return dict;
+    }
+    
+    NSMutableDictionary* soft_list_db = [[NSMutableDictionary alloc] init];
+    
+    // walk *all* of the software lists and build up database
+    [ZipFile enumerate:hash_zip withOptions:ZipFileEnumFiles usingBlock:^(ZipFileInfo* info) {
+        
+        if (![info.name.pathExtension.lowercaseString isEqualToString:@"xml"] || info.data == nil)
+            return;
+
+        NSDictionary* dict = [XmlFile dictionaryWithData:info.data error:nil];
+        
+        NSString* list_name = info.name.lastPathComponent.stringByDeletingPathExtension.lowercaseString;
+
+        // walk all software in this list and add to master db
+        for (NSDictionary* software in LIST([dict valueForKeyPath:@"softwarelist.software"])) {
+
+            if (![software isKindOfClass:[NSDictionary class]] || software[kSoftwareListName] == nil)
+                continue;
+            
+            NSString* name = STR(software[kSoftwareListName]).lowercaseString;
+            id val = soft_list_db[name];
+
+            if (val == nil)
+                soft_list_db[name] = list_name;
+            else
+                soft_list_db[name] = [LIST(val) arrayByAddingObject:list_name];
+        }
+    }];
+    
+    // SAVE the database to `HASH.DAT` for next time.
+    NSData* data = [NSPropertyListSerialization dataWithPropertyList:soft_list_db format:NSPropertyListBinaryFormat_v1_0 options:0 error:nil];
+    NSParameterAssert(data != nil);
+    [data writeToFile:hash_dat atomically:NO];
+    
+#if defined(DEBUG) && DebugLog != 0
+    for (NSString* key in soft_list_db.allKeys)
+        NSLog(@"    %@: %@", key, [LIST(soft_list_db[key]) componentsJoinedByString:@", "]);
+    NSLog(@"SoftwareListDatabase: %d items, HASH.DAT size=%d", (int)soft_list_db.allKeys.count, (int)[data length]);
+#endif
+    
+    return soft_list_db;
+}
 
 @end


### PR DESCRIPTION
* Handle full built in Software Lists from MAME (as HASH.ZIP)
* Don't import XML files anymore, not needed.
* Search for correct software list for a ROMSET by comparing SHA1 *not* the file names
* handle iOS 15 and iPad CMD+. keyboard shortcut.
* Added Menu (and button in Settings) to open Document directory in `Files.app` (or `Finder.app`)