### PR TITLE
Change PopupSegmentedController on tvOS

### DIFF
--- a/xcode/MAME4iOS/ChooseGameController.m
+++ b/xcode/MAME4iOS/ChooseGameController.m
@@ -230,13 +230,20 @@ typedef NS_ENUM(NSInteger, LayoutMode) {
         [UIImage systemImageNamed:@"rectangle.stack.fill"    withConfiguration:[UIImageSymbolConfiguration configurationWithPointSize:height]] ?: @"▢",
         [UIImage systemImageNamed:@"rectangle.grid.1x2.fill" withConfiguration:[UIImageSymbolConfiguration configurationWithPointSize:height]] ?: @"☰"
     ]];
-    
+    seg1.accessibilityLabel = @"View Options";
+    [seg1 imageForSegmentAtIndex:LayoutTiny].accessibilityLabel = @"Tiny";
+    [seg1 imageForSegmentAtIndex:LayoutSmall].accessibilityLabel = @"Small";
+    [seg1 imageForSegmentAtIndex:LayoutLarge].accessibilityLabel = @"Large";
+    [seg1 imageForSegmentAtIndex:LayoutList].accessibilityLabel = @"List";
+    NSParameterAssert(LayoutCount == 4);
+
     seg1.selectedSegmentIndex = _layoutMode;
     [seg1 addTarget:self action:@selector(viewChange:) forControlEvents:UIControlEventValueChanged];
     UIBarButtonItem* layout = [[UIBarButtonItem alloc] initWithCustomView:seg1];
 
     // group/scope
     UISegmentedControl* seg2 = [[PopupSegmentedControl alloc] initWithItems:ALL_SCOPES];
+    seg2.accessibilityLabel = @"Group Options";
     seg2.selectedSegmentIndex = [ALL_SCOPES indexOfObject:_gameFilterScope];
     seg2.apportionsSegmentWidthsByContent = TARGET_OS_IOS ? NO : YES;
     seg2.autoresizingMask = UIViewAutoresizingFlexibleHeight;   // make vertical menu always.

--- a/xcode/MAME4iOS/PopupSegmentedControl.h
+++ b/xcode/MAME4iOS/PopupSegmentedControl.h
@@ -10,7 +10,7 @@
 
 ///
 /// a subclass of UISegmentedControl that only shows the currently selected item, and lets the user change
-/// the currently selected item in a popup window on iOS. on tvOS the SegmentedControl will grow/shrink
+/// the currently selected item in a popup window on iOS, or an Alert on tvOS.
 ///
 /// - the main use for this controll is in a UIBarButtonItem in a UINavigationBar or a UIToolBar
 ///
@@ -21,6 +21,8 @@
 ///  You can force a Vertical popup always by setting UIViewAutoresizingFlexibleHeight
 ///
 /// - changing the list of items after init is currently not supported.
+///
+/// - accessibilityLabel is used as the Alert title on tvOS, and as text for UIImage items
 ///
 @interface PopupSegmentedControl : UISegmentedControl
 


### PR DESCRIPTION
have PopupSegmentedControl use an UIAlertViewController on tvOS to let user choose an option.

the Segmented Control used to grow and shrink when it got the focus, now it always stays the same size and shows an Alert when it is selected.

![Simulator Screen Shot - Apple TV - 2022-10-05 at 18 52 45](https://user-images.githubusercontent.com/4494698/194197382-5b750edc-a1d7-47e8-8f51-15b417a17c7f.png)
![Simulator Screen Shot - Apple TV - 2022-10-05 at 18 52 35](https://user-images.githubusercontent.com/4494698/194197388-19fb3000-70b3-4d50-9751-9747773ac35d.png)
