### PR TITLE
myosd_pad_x and y were switched, breaking iCade directions

### DIFF
--- a/iOS/KeyboardView.m
+++ b/iOS/KeyboardView.m
@@ -584,8 +584,8 @@
     }
     
     // emulate a analog joystick too.
-    myosd_pad_x = (myosd_pad_status & MYOSD_UP)    ? +1.0 : (myosd_pad_status & MYOSD_DOWN) ? -1.0 : 0.0;
-    myosd_pad_y = (myosd_pad_status & MYOSD_RIGHT) ? +1.0 : (myosd_pad_status & MYOSD_LEFT) ? -1.0 : 0.0;
+    myosd_pad_y = (myosd_pad_status & MYOSD_UP)    ? +1.0 : (myosd_pad_status & MYOSD_DOWN) ? -1.0 : 0.0;
+    myosd_pad_x = (myosd_pad_status & MYOSD_RIGHT) ? +1.0 : (myosd_pad_status & MYOSD_LEFT) ? -1.0 : 0.0;
 
     // only treat iCade as a controler when DPAD used for first time.
     if (g_joy_used == 0 && (myosd_pad_status & (MYOSD_DOWN|MYOSD_UP|MYOSD_RIGHT|MYOSD_LEFT)))


### PR DESCRIPTION
Please see https://github.com/yoshisuga/MAME4iOS/issues/448 for more information.